### PR TITLE
fix: eliminate auth race condition and false session-expired redirects

### DIFF
--- a/src/hooks/useAuthToken.js
+++ b/src/hooks/useAuthToken.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useAuth } from '@clerk/clerk-react';
 import { setAuthTokenGetter } from '../services/api';
 
@@ -16,12 +16,13 @@ export const useAuthToken = () => {
         return await getToken();
     }, [isSignedIn, getToken]);
 
-    useEffect(() => {
-        if (isLoaded) {
-            // Set the token getter function for the API service
-            setAuthTokenGetter(tokenGetter);
-        }
-    }, [isLoaded, tokenGetter]);
+    // Set synchronously on every render (not in useEffect).
+    // This ensures getAuthToken is available before any child component's
+    // useEffect fires, eliminating the race condition where Dashboard/other
+    // pages fire API calls before the token getter is registered.
+    if (isLoaded) {
+        setAuthTokenGetter(tokenGetter);
+    }
 
     return { isLoaded, isSignedIn };
 };

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -46,8 +46,10 @@ api.interceptors.response.use(
 
         switch (status) {
             case 401:
+                // Don't auto-redirect — ProtectedRoute + Clerk handle actual session expiry.
+                // Auto-redirecting caused false positives when the token getter wasn't
+                // attached yet on first render (race condition on page load).
                 toast.error('Session expired. Please sign in again.');
-                setTimeout(() => { window.location.href = '/'; }, 1500);
                 break;
             case 403:
                 toast.error('You don\'t have permission to do that.');


### PR DESCRIPTION
- useAuthToken: set the token getter synchronously on render (not in useEffect), so child components' effects always see a valid getter before their first API call fires
- api.js: remove auto-redirect on 401 — ProtectedRoute + Clerk already handle real session expiry via RedirectToSignIn; the redirect was causing false "session expired" boots on every fresh page load
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/venkat-kolasani/futurestack/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
