### PR TITLE
Interview rounds UI (PR3–PR5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ FutureTracker is a modern, full-featured SaaS application designed to help stude
 - **📈 Analytics**: Charts for status distribution, weekly trends, conversion funnels, and deadline heatmaps
 - **📄 PDF Export**: Generate professional reports with multiple export options
 - **📎 Documents**: Upload resumes, cover letters, and portfolio links; track which documents were used for each internship
+- **🎯 Interview pipeline**: Multi-round tracking for internships (OA → technical → HR → final) with timeline UI and auto-synced Kanban status — see [`docs/interview-rounds.md`](docs/interview-rounds.md)
 - **🎨 Modern UI**: Clean, dark-themed interface with smooth animations
 - **📱 Responsive**: Fully responsive design for all screen sizes
 
@@ -410,6 +411,10 @@ Authorization: Bearer <clerk_jwt_token>
 | POST | `/opportunities` | Create opportunity | ✅ |
 | PATCH | `/opportunities/:id` | Update opportunity | ✅ |
 | DELETE | `/opportunities/:id` | Delete opportunity | ✅ |
+| GET | `/opportunities/:id/rounds` | List interview rounds (internships) | ✅ |
+| POST | `/opportunities/:id/rounds` | Create round; returns `{ round, opportunity, rounds }` | ✅ |
+| PATCH | `/opportunities/:id/rounds/:roundId` | Update round; returns synced payload | ✅ |
+| DELETE | `/opportunities/:id/rounds/:roundId` | Delete round; returns synced payload | ✅ |
 | GET | `/analytics` | Get dashboard analytics | ✅ |
 | GET | `/me` | Get current user info | ✅ |
 
@@ -481,7 +486,8 @@ FutureStack is part of **GSSoC 2026**. Please read [CONTRIBUTING.md](CONTRIBUTIN
 ## 📚 Documentation
 
 - [Devin Wiki](https://app.devin.ai/wiki/Venkat-Kolasani/FutureStack) – canonical, always-current runbook with high-level decisions, architecture diagrams, and demo notes.
-- Local references: `docs/ARCHITECTURE.md`, `docs/DOCUMENTATION.md`, `docs/INTEGRATION_TEST_RESULTS.md`, and `docs/PROJECT_SUMMARY.md` provide offline deep dives, test evidence, and executive summaries.
+- [**Interview rounds**](docs/interview-rounds.md) – feature design, status sync, performance fix (good for technical interviews).
+- Local references: `docs/DOCUMENTATION.md`, `docs/TESTING.md`, and `docs/opportunity-rounds-migration.sql` provide offline deep dives, test steps, and schema.
 
 ---
 

--- a/backend/src/lib/syncOpportunityFromRounds.js
+++ b/backend/src/lib/syncOpportunityFromRounds.js
@@ -62,31 +62,43 @@ function deriveOpportunityFieldsFromRounds(rounds, existingStatus = 'applied') {
 
 /**
  * Load rounds for an opportunity and patch derived fields on opportunities row.
+ * Pass `existingStatus` and/or `rounds` to skip redundant reads when the caller already has them.
  */
-async function syncOpportunityFromRounds(supabase, opportunityId, userId) {
-    const { data: opportunity, error: oppError } = await supabase
-        .from('opportunities')
-        .select('id, status')
-        .eq('id', opportunityId)
-        .eq('user_id', userId)
-        .single();
+async function syncOpportunityFromRounds(supabase, opportunityId, userId, options = {}) {
+    let existingStatus = options.existingStatus;
+    let rounds = options.rounds;
 
-    if (oppError) {
-        throw oppError;
+    if (existingStatus === undefined) {
+        const { data: opportunity, error: oppError } = await supabase
+            .from('opportunities')
+            .select('id, status')
+            .eq('id', opportunityId)
+            .eq('user_id', userId)
+            .single();
+
+        if (oppError) {
+            throw oppError;
+        }
+
+        existingStatus = opportunity.status;
     }
 
-    const { data: rounds, error: roundsError } = await supabase
-        .from('opportunity_rounds')
-        .select('round_number, round_type, result')
-        .eq('opportunity_id', opportunityId)
-        .eq('user_id', userId)
-        .order('round_number', { ascending: true });
+    if (rounds === undefined) {
+        const { data: roundsData, error: roundsError } = await supabase
+            .from('opportunity_rounds')
+            .select('round_number, round_type, result')
+            .eq('opportunity_id', opportunityId)
+            .eq('user_id', userId)
+            .order('round_number', { ascending: true });
 
-    if (roundsError) {
-        throw roundsError;
+        if (roundsError) {
+            throw roundsError;
+        }
+
+        rounds = roundsData;
     }
 
-    const derived = deriveOpportunityFieldsFromRounds(rounds || [], opportunity.status);
+    const derived = deriveOpportunityFieldsFromRounds(rounds || [], existingStatus);
     const patch = {
         current_round_number: derived.current_round_number,
         rejected_round_number: derived.rejected_round_number

--- a/backend/src/routes/opportunity-rounds.js
+++ b/backend/src/routes/opportunity-rounds.js
@@ -53,7 +53,7 @@ function logAudit(action, userId, resourceId = null, outcome = 'success', detail
 async function verifyInternshipOpportunity(opportunityId, userId) {
     const { data, error } = await supabase
         .from('opportunities')
-        .select('id, category')
+        .select('id, category, status')
         .eq('id', opportunityId)
         .eq('user_id', userId)
         .single();
@@ -73,24 +73,35 @@ async function verifyInternshipOpportunity(opportunityId, userId) {
     return { valid: true, data };
 }
 
-async function getNextRoundNumber(opportunityId, userId) {
+async function listOpportunityRounds(opportunityId, userId) {
     const { data, error } = await supabase
         .from('opportunity_rounds')
-        .select('round_number')
+        .select('*')
         .eq('opportunity_id', opportunityId)
         .eq('user_id', userId)
-        .order('round_number', { ascending: false })
-        .limit(1);
+        .order('round_number', { ascending: true });
 
     if (error) {
         throw error;
     }
 
-    if (!data?.length) {
+    return data || [];
+}
+
+function getNextRoundNumberFromRounds(rounds) {
+    if (!rounds.length) {
         return 1;
     }
 
-    return data[0].round_number + 1;
+    return Math.max(...rounds.map((round) => round.round_number)) + 1;
+}
+
+function toSyncRoundFields(rounds) {
+    return rounds.map((round) => ({
+        round_number: round.round_number,
+        round_type: round.round_type,
+        result: round.result
+    }));
 }
 
 /**
@@ -135,7 +146,8 @@ router.post('/', validate(opportunityIdOnlyParamsSchema, 'params'), validate(cre
             return res.status(ownership.status).json({ error: ownership.error });
         }
 
-        const assignedRoundNumber = round_number ?? await getNextRoundNumber(opportunityId, userId);
+        const existingRounds = await listOpportunityRounds(opportunityId, userId);
+        const assignedRoundNumber = round_number ?? getNextRoundNumberFromRounds(existingRounds);
 
         const { data, error } = await supabase
             .from('opportunity_rounds')
@@ -158,14 +170,18 @@ router.post('/', validate(opportunityIdOnlyParamsSchema, 'params'), validate(cre
             throw error;
         }
 
-        await syncOpportunityFromRounds(supabase, opportunityId, userId);
+        const allRounds = [...existingRounds, data];
+        const opportunity = await syncOpportunityFromRounds(supabase, opportunityId, userId, {
+            existingStatus: ownership.data.status,
+            rounds: toSyncRoundFields(allRounds)
+        });
 
         logAudit('CREATE_ROUND', userId, data.id, 'success', {
             opportunity_id: opportunityId,
             round_number: assignedRoundNumber
         });
 
-        res.status(201).json(data);
+        res.status(201).json({ round: data, opportunity, rounds: allRounds });
     } catch (error) {
         return handleRouteError(res, 'CREATE_ROUND', error, 'Failed to create interview round');
     }
@@ -210,14 +226,18 @@ router.patch(
                 throw error;
             }
 
-            await syncOpportunityFromRounds(supabase, opportunityId, userId);
+            const allRounds = await listOpportunityRounds(opportunityId, userId);
+            const opportunity = await syncOpportunityFromRounds(supabase, opportunityId, userId, {
+                existingStatus: ownership.data.status,
+                rounds: toSyncRoundFields(allRounds)
+            });
 
             logAudit('UPDATE_ROUND', userId, roundId, 'success', {
                 opportunity_id: opportunityId,
                 updatedFields: Object.keys(updateData)
             });
 
-            res.json(data);
+            res.json({ round: data, opportunity, rounds: allRounds });
         } catch (error) {
             return handleRouteError(res, 'UPDATE_ROUND', error, 'Failed to update interview round');
         }
@@ -237,24 +257,31 @@ router.delete('/:roundId', validate(opportunityRoundParamsSchema, 'params'), asy
             return res.status(ownership.status).json({ error: ownership.error });
         }
 
-        const { error, count } = await supabase
+        const existingRounds = await listOpportunityRounds(opportunityId, userId);
+        const roundToDelete = existingRounds.find((round) => round.id === roundId);
+
+        if (!roundToDelete) {
+            return res.status(404).json({ error: 'Round not found' });
+        }
+
+        const { error } = await supabase
             .from('opportunity_rounds')
-            .delete({ count: 'exact' })
+            .delete()
             .eq('id', roundId)
             .eq('opportunity_id', opportunityId)
             .eq('user_id', userId);
 
         if (error) throw error;
 
-        if (count === 0) {
-            return res.status(404).json({ error: 'Round not found' });
-        }
-
-        await syncOpportunityFromRounds(supabase, opportunityId, userId);
+        const remainingRounds = existingRounds.filter((round) => round.id !== roundId);
+        const opportunity = await syncOpportunityFromRounds(supabase, opportunityId, userId, {
+            existingStatus: ownership.data.status,
+            rounds: toSyncRoundFields(remainingRounds)
+        });
 
         logAudit('DELETE_ROUND', userId, roundId, 'success', { opportunity_id: opportunityId });
 
-        res.json({ success: true, message: 'Round deleted' });
+        res.json({ success: true, message: 'Round deleted', opportunity, rounds: remainingRounds });
     } catch (error) {
         return handleRouteError(res, 'DELETE_ROUND', error, 'Failed to delete interview round');
     }

--- a/backend/src/validation/rounds-schemas.js
+++ b/backend/src/validation/rounds-schemas.js
@@ -1,8 +1,10 @@
 const Joi = require('joi');
 
 const ROUND_TYPES = [
+    'resume_shortlisted',
     'oa',
     'assignment',
+    'technical_assignment',
     'technical',
     'hr',
     'group_discussion',

--- a/backend/tests/integration/rounds.test.js
+++ b/backend/tests/integration/rounds.test.js
@@ -96,12 +96,6 @@ describe('Interview rounds API', () => {
                         error: null
                     });
                 }
-                if (opportunityCalls === 2) {
-                    return createChain({
-                        data: { id: OPPORTUNITY_ID, status: 'applied' },
-                        error: null
-                    });
-                }
                 return createChain({
                     data: {
                         id: OPPORTUNITY_ID,
@@ -135,7 +129,8 @@ describe('Interview rounds API', () => {
             .send({ round_type: 'oa', result: 'rejected' });
 
         expect(res.status).toBe(201);
-        expect(res.body.round_type).toBe('oa');
+        expect(res.body.round.round_type).toBe('oa');
+        expect(res.body.opportunity.status).toBe('rejected');
         expect(mockFrom).toHaveBeenCalledWith('opportunity_rounds');
     });
 
@@ -149,12 +144,6 @@ describe('Interview rounds API', () => {
                 if (opportunityCalls === 1) {
                     return createChain({
                         data: { id: OPPORTUNITY_ID, category: 'internship', status: 'applied' },
-                        error: null
-                    });
-                }
-                if (opportunityCalls === 2) {
-                    return createChain({
-                        data: { id: OPPORTUNITY_ID, status: 'applied' },
                         error: null
                     });
                 }
@@ -185,7 +174,13 @@ describe('Interview rounds API', () => {
                     });
                 }
                 return listChain([
-                    { round_number: 1, round_type: 'oa', result: 'rejected' }
+                    {
+                        id: ROUND_ID,
+                        opportunity_id: OPPORTUNITY_ID,
+                        round_number: 1,
+                        round_type: 'oa',
+                        result: 'rejected'
+                    }
                 ]);
             }
 
@@ -198,7 +193,8 @@ describe('Interview rounds API', () => {
             .send({ result: 'rejected' });
 
         expect(res.status).toBe(200);
-        expect(res.body.result).toBe('rejected');
+        expect(res.body.round.result).toBe('rejected');
+        expect(res.body.opportunity.status).toBe('rejected');
     });
 
     it('GET /api/opportunities/:id/rounds returns 404 for unknown opportunity', async () => {

--- a/backend/tests/unit/syncOpportunityFromRounds.test.js
+++ b/backend/tests/unit/syncOpportunityFromRounds.test.js
@@ -8,6 +8,18 @@ describe('deriveOpportunityFieldsFromRounds', () => {
         });
     });
 
+    it('marks rejected at round 1', () => {
+        expect(
+            deriveOpportunityFieldsFromRounds([
+                { round_number: 1, round_type: 'resume_shortlisted', result: 'rejected' }
+            ])
+        ).toEqual({
+            status: 'rejected',
+            current_round_number: null,
+            rejected_round_number: 1
+        });
+    });
+
     it('marks rejected at the failing round', () => {
         expect(
             deriveOpportunityFieldsFromRounds([

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -313,7 +313,48 @@ erDiagram
     }
 ```
 
-Interview rounds track multi-stage hiring pipelines (OA, technical, HR, etc.) per **internship** opportunity. See [`docs/opportunity-rounds-migration.sql`](opportunity-rounds-migration.sql).
+Interview rounds track multi-stage hiring pipelines (OA, technical, HR, etc.) per **internship** opportunity. See [`docs/opportunity-rounds-migration.sql`](opportunity-rounds-migration.sql) and the full guide [`docs/interview-rounds.md`](interview-rounds.md).
+
+---
+
+## Interview Round Tracking
+
+Multi-round hiring pipeline for internships: timeline UI, per-round results, and automatic sync of Kanban `status` plus `current_round_number` / `rejected_round_number`.
+
+**Quick reference for interviews:** [`docs/interview-rounds.md`](interview-rounds.md)
+
+### API routes
+
+Nested under opportunities (internships only):
+
+| Method | Endpoint | Notes |
+|--------|----------|-------|
+| GET | `/api/opportunities/:opportunityId/rounds` | Ordered by `round_number` |
+| POST | `/api/opportunities/:opportunityId/rounds` | Returns `{ round, opportunity, rounds }` |
+| PATCH | `/api/opportunities/:opportunityId/rounds/:roundId` | Same unified response |
+| DELETE | `/api/opportunities/:opportunityId/rounds/:roundId` | Same + `success` flag |
+
+Frontend uses `roundService` in `src/services/api.js` only — no direct Supabase CRUD for rounds.
+
+### Performance: slow round save (fixed)
+
+**Problem:** Creating a round felt sluggish — users waited several seconds before the success toast.
+
+**Root cause:**
+
+- Backend ran **6 sequential Supabase queries** on create (verify, next-number lookup, insert, then sync re-fetched opportunity + rounds before update).
+- Frontend then fired **2 more API calls** (`getById` + list rounds) and kept the modal on “Saving…” until both finished.
+
+**Fix:**
+
+1. **Batch reads** — list rounds once; reuse for next `round_number` and for `deriveOpportunityFieldsFromRounds()`.
+2. **Skip redundant sync SELECTs** — `syncOpportunityFromRounds(supabase, id, userId, { existingStatus, rounds })`.
+3. **Unified mutation response** — POST/PATCH/DELETE return `{ round, opportunity, rounds }`.
+4. **Frontend applies response in place** — `applyRoundMutationResult()` in `OpportunityDetailModal`; no blocking refetch.
+
+**Result:** Create path **6 → 4** DB round-trips; UI updates from a single HTTP response.
+
+See [`docs/interview-rounds.md`](interview-rounds.md#performance-issue--fix) for the interview one-liner and file map.
 
 ### Row Level Security (RLS)
 
@@ -355,7 +396,14 @@ USING (
 - **Auto-logout on 401**: Expired sessions handled gracefully
 - **Skeleton Loading**: Premium loading states for all data-heavy views
 
-### 5. Product Analytics (PostHog)
+### 5. Interview Round Tracking (internships)
+- **Multi-round pipeline**: OA, technical, HR, final — per-round type, date, result, notes
+- **Timeline UI** in internship detail drawer; compact badge on cards
+- **Auto status sync**: Round results update Kanban `status` and `current_round_number` / `rejected_round_number`
+- **Performance**: Mutations return `{ round, opportunity, rounds }`; UI applies in one shot (no blocking refetch)
+- **Docs**: [`docs/interview-rounds.md`](interview-rounds.md)
+
+### 6. Product Analytics (PostHog)
 - **User Behavior Tracking**: Page views, feature usage, and user flows
 - **Event Tracking**: Custom events for opportunity creation, updates, deletions
 - **Autocapture**: Automatic click and form submission tracking
@@ -457,6 +505,25 @@ api.interceptors.response.use(
 **Problem**: The custom calendar view was showing misaligned days, with the Sunday column wrapping to the next line, causing significant confusion.
 
 **Solution**: Removed the margin and relied on borders for visual separation, ensuring the 7-column grid fits perfectly within the container.
+
+---
+
+### Challenge 5: Interview Round Save Latency
+
+**Problem**: After adding interview round tracking, saving a round felt slow — users stared at “Saving…” for several seconds before seeing success feedback.
+
+**Root cause**: A naive create flow chained **6 sequential Supabase calls** (verify opportunity, query max round number, insert, then sync re-read opportunity + rounds, then update). The frontend then issued **two more REST calls** to refetch opportunity and rounds before closing the modal.
+
+**Solution**:
+
+1. Fetch rounds once at the start of create; derive next `round_number` in memory.
+2. Pass `existingStatus` and `rounds` into `syncOpportunityFromRounds()` so sync only runs the final `UPDATE`.
+3. Return `{ round, opportunity, rounds }` from POST/PATCH/DELETE.
+4. Apply that payload in `OpportunityDetailModal` via `applyRoundMutationResult()` — toast and modal close immediately.
+
+**Interview takeaway**: Reduced DB round-trips and eliminated redundant client refetches by designing the API response for the UI’s exact needs.
+
+Full write-up: [`docs/interview-rounds.md`](interview-rounds.md#performance-issue--fix)
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,6 +34,7 @@ export REACT_APP_API_URL=http://localhost:3001/api
 | `backend/src/routes/*` or `backend/src/middleware/*` | `cd backend && npm test` — **add or update tests** in `backend/tests/` |
 | `backend/src/lib/validation.js` | `cd backend && npm test -- validation` |
 | `docs/*-migration.sql` | Manual: run migration on a dev Supabase project; document steps in the PR |
+| Interview rounds (`backend/src/routes/opportunity-rounds.js`, `src/components/rounds/*`) | `cd backend && npm test -- rounds`, manual flow in [`docs/interview-rounds.md`](interview-rounds.md#testing), optional `./scripts/test-rounds-api.sh` |
 
 ### Backend route changes require tests
 
@@ -54,6 +55,20 @@ Use this after automated tests pass:
 5. Exercise the happy path once
 6. Try one edge case (empty state, invalid input, expired deadline, etc.)
 7. If you touched auth or API wiring: hard-refresh and confirm data still loads on first paint
+
+### Interview rounds (if you changed round API or UI)
+
+See [`docs/interview-rounds.md`](interview-rounds.md#testing).
+
+1. Open an internship → detail drawer → **Interview Pipeline**
+2. Add a round — save should complete quickly (toast + timeline without long **Saving…**)
+3. Edit result to `rejected` — status badge and card summary update
+4. Confirm hackathon detail drawer has **no** rounds section
+
+```bash
+export CLERK_TOKEN="<paste from browser Clerk session>"
+./scripts/test-rounds-api.sh
+```
 
 ## What CI runs
 

--- a/docs/future.md
+++ b/docs/future.md
@@ -116,8 +116,8 @@ let getAuthToken = null; // Global state
 - **Value**: Find opportunities quickly as list grows
 
 #### 8. Interview Tracker
-- [ ] Track interview rounds (Phone → Technical → Onsite → HR)
-- [ ] Add interviewer names & notes
+- [x] Track interview rounds (OA → Technical → HR → Final) — see [`docs/interview-rounds.md`](interview-rounds.md)
+- [x] Per-round notes and results with timeline UI
 - [ ] Interview prep checklists per company
 - [ ] Calendar integration for interview scheduling
 - **Value**: Comprehensive interview management

--- a/docs/interview-rounds.md
+++ b/docs/interview-rounds.md
@@ -1,0 +1,171 @@
+# Interview Round Tracking
+
+> **Interview talking point:** Multi-round hiring pipelines for internships — timeline UI, automatic Kanban status sync, and a performance fix that cut save latency by eliminating redundant database round-trips and frontend refetches.
+
+## Problem
+
+`opportunities.status` alone (`applied`, `shortlisted`, `interviewed`, …) cannot represent real hiring flows:
+
+- Users need to record **each round** (OA, technical, HR, final) with type, date, result, and notes.
+- Users need to see **where they failed** (`Rejected at Round 2`) or **what is next** (`Round 3 · In progress`).
+- Kanban and analytics must stay consistent without a separate `current_stage` column.
+
+## Solution overview
+
+| Layer | What we built |
+|-------|----------------|
+| **Database** | `opportunity_rounds` table + `current_round_number` / `rejected_round_number` on `opportunities` |
+| **Backend** | Nested REST routes under `/api/opportunities/:id/rounds` + `syncOpportunityFromRounds()` |
+| **Frontend** | `RoundTimeline`, `AddRoundModal`, `roundService` in `api.js`, internship detail drawer + card badges |
+
+**Scope:** internships only (`category === 'internship'`). Hackathons use the collaboration workspace.
+
+**Architecture rule:** all round reads/writes go through Express (`roundService`). No `supabase.from()` for rounds in the frontend.
+
+---
+
+## API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/opportunities/:opportunityId/rounds` | List rounds (ordered by `round_number`) |
+| POST | `/api/opportunities/:opportunityId/rounds` | Create round (auto `round_number` if omitted) |
+| PATCH | `/api/opportunities/:opportunityId/rounds/:roundId` | Update type, date, result, notes |
+| DELETE | `/api/opportunities/:opportunityId/rounds/:roundId` | Delete round; re-sync parent opportunity |
+
+### Mutation response shape (POST / PATCH / DELETE)
+
+Mutations return everything the UI needs in **one response** — no follow-up refetch required:
+
+```json
+{
+  "round": { "id": "...", "round_number": 2, "round_type": "technical", "result": "pending", ... },
+  "opportunity": { "id": "...", "status": "interviewed", "current_round_number": 2, "rejected_round_number": null, ... },
+  "rounds": [ /* full ordered list after the mutation */ ]
+}
+```
+
+DELETE also includes `"success": true` and `"message": "Round deleted"`.
+
+### Status sync rules
+
+Implemented in `backend/src/lib/syncOpportunityFromRounds.js` → `deriveOpportunityFieldsFromRounds()`:
+
+| Condition | `status` | `current_round_number` | `rejected_round_number` |
+|-----------|----------|------------------------|-------------------------|
+| No rounds | unchanged | `null` | `null` |
+| Any round `rejected` | `rejected` | `null` | that round # |
+| A round `pending` | `interviewed` | that round # | `null` |
+| All cleared/skipped, not final | `shortlisted` or `interviewed` | `null` | `null` |
+| `final` round `cleared` | `selected` | `null` | `null` |
+
+---
+
+## Performance issue & fix
+
+### Symptom
+
+Saving a round felt slow: long wait from clicking **Add round** until the success toast and timeline update.
+
+### Root cause (naive first implementation)
+
+**Backend — 6 sequential Supabase calls per create:**
+
+1. Verify opportunity exists  
+2. Query max `round_number`  
+3. Insert round  
+4. `syncOpportunityFromRounds`: fetch opportunity again  
+5. Fetch all rounds again  
+6. Patch opportunity  
+
+Each remote DB hop adds ~100–300ms+ → multi-second saves.
+
+**Frontend — 2 extra API calls after create:**
+
+1. `GET /opportunities/:id`  
+2. `GET /opportunities/:id/rounds`  
+
+The modal stayed on **Saving…** until both completed, even after the create returned.
+
+### Fix
+
+**Backend (fewer round-trips):**
+
+1. Fetch all rounds **once** at the start of create (also used for next `round_number`).
+2. Insert the new round.
+3. Call `syncOpportunityFromRounds()` with **preloaded** `existingStatus` and `rounds` so sync skips redundant SELECTs — only the final UPDATE hits the DB.
+4. Return `{ round, opportunity, rounds }` from POST, PATCH, and DELETE.
+
+**Create path:** 6 DB calls → **4** (verify → list rounds → insert → update opportunity).
+
+**Frontend (no blocking refetch):**
+
+1. Apply `opportunity` and `rounds` from the mutation response directly to React state.
+2. Close modal and show toast immediately.
+3. Update internship list via `onOpportunityUpdated` callback (card badges stay in sync).
+
+### Key files
+
+| File | Role |
+|------|------|
+| `backend/src/routes/opportunity-rounds.js` | Optimized create/update/delete flow |
+| `backend/src/lib/syncOpportunityFromRounds.js` | Optional `existingStatus` + `rounds` to skip reads |
+| `src/components/opportunities/OpportunityDetailModal.jsx` | `applyRoundMutationResult()` — no post-save refetch |
+| `src/services/api.js` | `roundService` |
+
+### Interview one-liner
+
+> “Round save was slow because we chained six Supabase queries on create plus two frontend refetches. I batched the round list read, passed derived state into sync to skip duplicate SELECTs, returned the full payload from the mutation, and updated the UI from that single response instead of blocking on refetch.”
+
+---
+
+## Frontend components
+
+```
+src/components/rounds/
+├── RoundTimeline.jsx    # Vertical stepper (presentational)
+└── AddRoundModal.jsx    # Create / edit form
+
+src/utils/roundHelpers.js   # Labels, enums, card summary text
+src/services/api.js           # roundService
+```
+
+**Integration points:**
+
+- `OpportunityDetailModal` — Interview Pipeline section (internships only)
+- `OpportunityCard` — compact badge via `getRoundSummaryLabel()`
+- `InternshipList` — `onOpportunityUpdated` keeps list + drawer in sync
+
+---
+
+## Testing
+
+```bash
+# Automated
+cd backend && npm test -- rounds
+npm run test:ci
+npm run check:architecture
+
+# Schema (after migration)
+npm run verify:rounds-schema
+
+# Manual API smoke (needs Clerk JWT)
+export CLERK_TOKEN="$(# browser: copy(await window.Clerk.session.getToken()))"
+./scripts/test-rounds-api.sh
+```
+
+**Manual UX checklist:**
+
+1. Open internship → **Interview Pipeline** → **Add round**
+2. Save should feel snappy; toast + timeline update without long **Saving…**
+3. Mark round rejected → status `rejected`, banner + card badge update
+4. Clear final round → status `selected`
+5. Hackathon detail drawer must **not** show rounds UI
+
+---
+
+## Related docs
+
+- Migration SQL: [`opportunity-rounds-migration.sql`](opportunity-rounds-migration.sql)
+- Epic & PR breakdown: [`issues/interview-rounds-epic.md`](issues/interview-rounds-epic.md)
+- Full technical doc: [`DOCUMENTATION.md`](DOCUMENTATION.md#interview-round-tracking)

--- a/docs/issues/interview-rounds-epic.md
+++ b/docs/issues/interview-rounds-epic.md
@@ -1,0 +1,56 @@
+### Summary
+
+Track **multi-round interview pipelines** per internship opportunity (OA → Technical → HR → Final, etc.) with a visual timeline, per-round results, and rejection-at-round visibility.
+
+**Status:** Shipped (schema + API + UI on `main` / PR #56).
+
+### Problem
+
+Today `opportunities.status` is a single flat value (`applied`, `shortlisted`, `interviewed`, `selected`, `rejected`). Real hiring flows have many rounds; users cannot record where they are, what is upcoming, or which round they failed.
+
+### Solution (5 PRs)
+
+| PR | Issue | Scope | Status |
+|----|-------|--------|--------|
+| 1 | DB schema | `opportunity_rounds` table + RLS + opportunity columns | ✅ Merged |
+| 2 | API | CRUD + status sync helper | ✅ Merged |
+| 3 | UI | Presentational `RoundTimeline` | ✅ Merged |
+| 4 | UI | `AddRoundModal` + helpers | ✅ Merged |
+| 5 | Integration | Wire into detail modal + card badges | ✅ PR #56 |
+
+### Design decisions (read before any PR)
+
+1. **Internships only** — hackathons use `/hackathons/:id` collaboration; rounds are not for `category = 'hackathon'`.
+2. **No `current_stage` column** — keep existing `opportunities.status` for Kanban/analytics. Add `current_round_number` and `rejected_round_number` for quick display. Backend syncs `status` when round results change.
+3. **API via Express only** — frontend uses `src/services/api.js`; no `supabase.from()` for rounds.
+4. **Nested routes** — follow hackathons pattern: `/api/opportunities/:opportunityId/rounds`.
+5. **Tailwind only** — no separate CSS files.
+6. **Unified mutation responses** — POST/PATCH/DELETE return `{ round, opportunity, rounds }` so the UI does not refetch after every save (performance).
+
+### Status sync rules
+
+| Condition | `opportunities.status` | `rejected_round_number` | `current_round_number` |
+|-----------|------------------------|-------------------------|------------------------|
+| No rounds | unchanged (usually `applied`) | null | null |
+| Any round `rejected` | `rejected` | that round # | null |
+| A round `pending` | `interviewed` | null | that round # |
+| All cleared/skipped, not final | `shortlisted` or `interviewed` | null | null |
+| `final` round `cleared` | `selected` | null | null |
+
+### Performance fix (post-launch)
+
+Slow round save was caused by 6 sequential Supabase calls on create + 2 frontend refetches. Fixed by batching round list read, preloading sync inputs, and applying mutation response in the UI. See [`docs/interview-rounds.md`](../interview-rounds.md#performance-issue--fix).
+
+### Out of scope (follow-ups)
+
+- Calendar reminders per round
+- Analytics funnel by round type
+- Browser extension auto-import
+
+### Migration
+
+SQL: [`docs/opportunity-rounds-migration.sql`](../opportunity-rounds-migration.sql)
+
+### Interview reference
+
+[`docs/interview-rounds.md`](../interview-rounds.md) — problem, architecture, API, performance story, testing.

--- a/docs/issues/interview-rounds-pr1-schema.md
+++ b/docs/issues/interview-rounds-pr1-schema.md
@@ -1,0 +1,64 @@
+### Summary
+
+Add Supabase schema for **interview round tracking** — foundation for all follow-up PRs.
+
+**Status:** ✅ Merged (`docs/opportunity-rounds-migration.sql`)
+
+**Docs:** [`docs/interview-rounds.md`](../interview-rounds.md)
+
+### Tasks
+
+- [ ] Add `docs/opportunity-rounds-migration.sql` (or finalize existing draft)
+- [ ] Run migration on dev Supabase project
+- [ ] Update `docs/DOCUMENTATION.md` ER diagram section with `opportunity_rounds`
+- [ ] Update README database schema Mermaid if table list changes
+
+### Schema
+
+**New table: `opportunity_rounds`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid PK | |
+| `opportunity_id` | uuid FK → opportunities | CASCADE delete |
+| `user_id` | uuid FK → users | RLS + ownership |
+| `round_number` | integer ≥ 1 | unique per opportunity |
+| `round_type` | text enum | `oa`, `assignment`, `technical`, `hr`, `group_discussion`, `managerial`, `final`, `other` |
+| `scheduled_date` | date nullable | |
+| `result` | text enum | `pending`, `cleared`, `rejected`, `skipped` (default `pending`) |
+| `notes` | text nullable | |
+| `created_at` / `updated_at` | timestamptz | reuse `update_updated_at_column` trigger |
+
+**Alter `opportunities`:**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `current_round_number` | integer nullable | active/upcoming round |
+| `rejected_round_number` | integer nullable | set when rejected at a round |
+
+**Do NOT add `current_stage`** — use existing `status` column (synced in PR2).
+
+### RLS
+
+- All CRUD scoped to authenticated user's `user_id`
+- INSERT must target `category = 'internship'` opportunities owned by user
+
+### Acceptance criteria
+
+- [ ] Migration applies cleanly on empty and existing databases
+- [ ] Indexes on `opportunity_id`, `user_id`, `scheduled_date`
+- [ ] RLS policies tested manually in Supabase SQL editor
+- [ ] No changes to frontend or API in this PR
+
+### Files
+
+- `docs/opportunity-rounds-migration.sql`
+- `docs/DOCUMENTATION.md` (schema section)
+
+### Depends on
+
+Nothing — **merge this first**.
+
+### Blocks
+
+PR2 API, PR3 Timeline UI (mock data ok), PR4 Modal UI (mock data ok)

--- a/docs/issues/interview-rounds-pr2-api.md
+++ b/docs/issues/interview-rounds-pr2-api.md
@@ -1,0 +1,88 @@
+### Summary
+
+Backend CRUD for interview rounds + **status sync** on the parent opportunity.
+
+**Status:** Implemented (merged). Performance optimized: mutations return `{ round, opportunity, rounds }` to avoid redundant DB reads and frontend refetches.
+
+### API routes
+
+Mount nested under opportunities (same pattern as hackathons):
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/opportunities/:opportunityId/rounds` | List rounds ordered by `round_number` |
+| POST | `/api/opportunities/:opportunityId/rounds` | Add round (auto-assign next `round_number` if omitted) |
+| PATCH | `/api/opportunities/:opportunityId/rounds/:roundId` | Update type, date, result, notes |
+| DELETE | `/api/opportunities/:opportunityId/rounds/:roundId` | Delete round; re-sync opportunity fields |
+
+All routes require auth. Verify opportunity belongs to user and `category === 'internship'`.
+
+### Mutation response (POST / PATCH / DELETE)
+
+```json
+{
+  "round": { ... },
+  "opportunity": { "status": "interviewed", "current_round_number": 2, ... },
+  "rounds": [ ... ]
+}
+```
+
+The UI applies this payload directly — no follow-up `GET` for opportunity + rounds.
+
+### Status sync helper
+
+`backend/src/lib/syncOpportunityFromRounds.js`:
+
+- After every round create/update/delete, recompute:
+  - `opportunities.status`
+  - `current_round_number`
+  - `rejected_round_number`
+- Accepts optional `{ existingStatus, rounds }` to **skip redundant SELECTs** when the route already loaded that data (performance fix).
+
+### Create flow (optimized)
+
+| Step | DB action |
+|------|-----------|
+| 1 | Verify opportunity (`id`, `category`, `status`) |
+| 2 | List existing rounds (also used for next `round_number`) |
+| 3 | Insert new round |
+| 4 | Sync with preloaded data → single `UPDATE` on opportunity |
+
+**Before:** 6 sequential Supabase calls. **After:** 4.
+
+### Validation (Joi)
+
+`backend/src/validation/rounds-schemas.js`:
+
+- `round_type` enum
+- `result` enum
+- `scheduled_date` optional ISO date
+- `notes` max 5000 chars
+- `round_number` optional on create (server assigns max+1)
+
+### Tests
+
+- `backend/tests/integration/rounds.test.js`
+  - 401 without auth
+  - 404 wrong opportunity
+  - 400 invalid round_type
+  - Create → `res.body.round` + `res.body.opportunity.status === 'rejected'`
+  - Reject hackathon opportunity → 400
+
+### Files
+
+- `backend/src/routes/opportunity-rounds.js`
+- `backend/src/lib/syncOpportunityFromRounds.js`
+- `backend/src/validation/rounds-schemas.js`
+- `backend/tests/integration/rounds.test.js`
+
+### Docs
+
+- [`docs/interview-rounds.md`](../interview-rounds.md) — interview talking points + performance fix
+
+### Acceptance criteria
+
+- [x] All endpoints work with Clerk JWT
+- [x] Status sync covered by integration tests
+- [x] `cd backend && npm test` passes
+- [x] Mutations return unified payload for fast UI updates

--- a/docs/issues/interview-rounds-pr3-timeline.md
+++ b/docs/issues/interview-rounds-pr3-timeline.md
@@ -1,0 +1,57 @@
+### Summary
+
+Presentational **RoundTimeline** component — vertical stepper showing each round's type, date, and result.
+
+**Status:** ✅ Implemented — `src/components/rounds/RoundTimeline.jsx`
+
+**Docs:** [`docs/interview-rounds.md`](../interview-rounds.md)
+
+### Props
+
+```jsx
+<RoundTimeline
+  rounds={rounds}           // sorted by round_number
+  currentRoundNumber={2}    // optional highlight
+  rejectedRoundNumber={null}
+/>
+```
+
+### UI requirements
+
+- Each step: round number, type label, scheduled date, result badge
+- Result colors (Tailwind):
+  - `pending` → blue
+  - `cleared` → green
+  - `rejected` → red
+  - `skipped` → gray
+- Banner: **"Rejected at Round N"** when `rejectedRoundNumber` set
+- Banner: **"Preparing for Round N"** when latest result is `pending`
+- Empty state: "No rounds yet — add your first round after applying"
+- Accessible: list semantics, sufficient contrast on dark theme
+
+### Files
+
+- `src/components/rounds/RoundTimeline.jsx` (new)
+- `src/components/rounds/RoundTimeline.test.jsx` (optional but encouraged — render with mock data)
+- `src/utils/roundHelpers.js` (new) — `ROUND_TYPE_LABELS`, `RESULT_LABELS`, icons map
+
+### Out of scope
+
+- API calls
+- Modals
+- OpportunityCard integration
+
+### Acceptance criteria
+
+- [ ] Renders correctly with 0, 1, and 5 mock rounds
+- [ ] Storybook not required; manual screenshot in PR is fine
+- [ ] Uses Tailwind only (no `.css` file)
+- [ ] `npm run test:ci` passes
+
+### Depends on
+
+PR1 (constants/types). **Can parallel PR2** using mocks.
+
+### Blocks
+
+PR5 integration

--- a/docs/issues/interview-rounds-pr4-modal.md
+++ b/docs/issues/interview-rounds-pr4-modal.md
@@ -1,0 +1,52 @@
+### Summary
+
+**AddRoundModal** (and edit mode) for creating/updating interview rounds.
+
+**Status:** ✅ Implemented — `src/components/rounds/AddRoundModal.jsx`
+
+**Docs:** [`docs/interview-rounds.md`](../interview-rounds.md)
+
+**Blocked by:** PR1 schema. UI can be built with mock submit handler before PR2 merges.
+
+### Fields
+
+| Field | Control |
+|-------|---------|
+| Round type | Select: OA, Assignment, Technical Interview, HR Interview, Group Discussion, Managerial, Final Round, Other |
+| Scheduled date | Date input (optional) |
+| Result | Select: Pending, Cleared, Rejected, Skipped |
+| Notes | Textarea (optional) |
+
+### Behavior
+
+- **Add mode:** title "Add Round N" where N = next round number (prop)
+- **Edit mode:** pre-fill existing round; title "Edit Round N"
+- Validate required round type
+- On submit: call prop `onSubmit(payload)` — parent wires API in PR5
+- Loading + error states on submit button
+- Dark theme consistent with `Modal.jsx`
+
+### Files
+
+- `src/components/rounds/AddRoundModal.jsx` (new)
+- Extend `src/utils/roundHelpers.js` if not created in PR3
+
+### Out of scope
+
+- Fetching rounds
+- OpportunityCard / DetailModal wiring
+
+### Acceptance criteria
+
+- [ ] Add and edit modes work with mock `onSubmit`
+- [ ] Form resets on close
+- [ ] Keyboard accessible (focus trap via existing Modal)
+- [ ] `npm run test:ci` passes
+
+### Depends on
+
+PR1. **Can parallel PR2 and PR3.**
+
+### Blocks
+
+PR5 integration

--- a/docs/issues/interview-rounds-pr5-integration.md
+++ b/docs/issues/interview-rounds-pr5-integration.md
@@ -1,0 +1,60 @@
+### Summary
+
+Wire interview rounds into the **internship opportunity UX** — detail modal, card badge, API service layer.
+
+**Status:** Implemented. UI updates from mutation response without blocking refetch.
+
+### User flow
+
+1. User opens internship in `OpportunityDetailModal`
+2. Section: **Interview pipeline** with `RoundTimeline`
+3. **Add round** / **Edit round** opens `AddRoundModal`
+4. Save calls API → `applyRoundMutationResult()` updates timeline + card badges immediately
+5. `OpportunityCard` shows compact line: e.g. `Round 2 · In progress` or `Rejected at Round 1`
+
+### API service
+
+`src/services/api.js`:
+
+```js
+export const roundService = {
+  list(opportunityId) { ... },
+  create(opportunityId, data) { ... },   // returns { round, opportunity, rounds }
+  update(opportunityId, roundId, data) { ... },
+  delete(opportunityId, roundId) { ... },
+};
+```
+
+**Do not** add Supabase queries in `src/lib/supabase.js` for rounds.
+
+### Performance (UX)
+
+**Before:** After create, modal waited for `getById` + `list` refetch before closing.
+
+**After:** `handleRoundSubmit` applies `{ round, opportunity, rounds }` from the mutation response, closes modal, shows toast — no extra HTTP calls.
+
+### Status board / filters
+
+- Kanban columns still use `opportunities.status` (auto-synced by API)
+- `InternshipList` passes `onOpportunityUpdated` to refresh card badges in the list
+
+### Files
+
+- `src/services/api.js` — `roundService`
+- `src/components/rounds/RoundTimeline.jsx`
+- `src/components/rounds/AddRoundModal.jsx`
+- `src/utils/roundHelpers.js`
+- `src/components/opportunities/OpportunityDetailModal.jsx`
+- `src/components/opportunities/OpportunityCard.jsx`
+- `src/pages/InternshipList.jsx`
+
+### Acceptance criteria
+
+- [x] End-to-end: add rounds, mark rejected → status + banner + card update
+- [x] Hackathon opportunities do not show rounds UI
+- [x] `npm run test:ci` and `npm run check:architecture` pass
+- [x] Round save feels responsive (no blocking refetch)
+
+### Docs
+
+- [`docs/interview-rounds.md`](../interview-rounds.md)

--- a/docs/opportunity-rounds-migration.sql
+++ b/docs/opportunity-rounds-migration.sql
@@ -3,7 +3,7 @@
 -- Multi-round application pipeline tracking (internships only)
 -- =============================================================================
 
--- Round types: oa, assignment, technical, hr, group_discussion, managerial, final, other
+-- Round types: resume_shortlisted, oa, assignment, technical_assignment, technical, hr, ...
 -- Results: pending, cleared, rejected, skipped
 
 CREATE TABLE IF NOT EXISTS opportunity_rounds (
@@ -12,8 +12,10 @@ CREATE TABLE IF NOT EXISTS opportunity_rounds (
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   round_number INTEGER NOT NULL CHECK (round_number >= 1),
   round_type TEXT NOT NULL CHECK (round_type IN (
+    'resume_shortlisted',
     'oa',
     'assignment',
+    'technical_assignment',
     'technical',
     'hr',
     'group_discussion',

--- a/docs/opportunity-rounds-round-types-patch.sql
+++ b/docs/opportunity-rounds-round-types-patch.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- Patch: add resume_shortlisted and technical_assignment round types
+-- Run in Supabase SQL Editor if opportunity_rounds already exists.
+-- =============================================================================
+
+ALTER TABLE opportunity_rounds
+  DROP CONSTRAINT IF EXISTS opportunity_rounds_round_type_check;
+
+ALTER TABLE opportunity_rounds
+  ADD CONSTRAINT opportunity_rounds_round_type_check
+  CHECK (round_type IN (
+    'resume_shortlisted',
+    'oa',
+    'assignment',
+    'technical_assignment',
+    'technical',
+    'hr',
+    'group_discussion',
+    'managerial',
+    'final',
+    'other'
+  ));

--- a/scripts/test-rounds-api.sh
+++ b/scripts/test-rounds-api.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Test interview rounds API locally.
+# Usage:
+#   export CLERK_TOKEN="eyJ..."   # from browser (see below)
+#   export OPP_ID="uuid-here"     # internship opportunity id
+#   bash scripts/test-rounds-api.sh
+#
+# Get CLERK_TOKEN (signed in at http://localhost:3000):
+#   DevTools → Console → paste:
+#   copy(await window.Clerk.session.getToken())
+#
+# Get OPP_ID:
+#   curl -s -H "Authorization: Bearer $CLERK_TOKEN" http://localhost:3001/api/opportunities | jq '.[0].id'
+
+set -euo pipefail
+
+API="${API_URL:-http://localhost:3001/api}"
+TOKEN="${CLERK_TOKEN:-}"
+OPP_ID="${OPP_ID:-}"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "Error: Set CLERK_TOKEN first."
+  echo '  export CLERK_TOKEN="$(pbpaste)"   # after copy(await window.Clerk.session.getToken())'
+  exit 1
+fi
+
+if [[ -z "$OPP_ID" ]]; then
+  echo "Fetching your opportunities to pick an internship..."
+  LIST=$(curl -s -H "Authorization: Bearer $TOKEN" "$API/opportunities")
+  OPP_ID=$(echo "$LIST" | node -e "
+    const rows = JSON.parse(require('fs').readFileSync(0,'utf8'));
+    const internship = rows.find((r) => r.category === 'internship');
+    if (!internship) { process.exit(1); }
+    console.log(internship.id);
+  " 2>/dev/null) || {
+    echo "Error: No internship found. Create one in the app or set OPP_ID manually."
+    exit 1
+  }
+  echo "Using OPP_ID=$OPP_ID"
+fi
+
+echo ""
+echo "=== GET rounds ==="
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$API/opportunities/$OPP_ID/rounds" | node -e "console.log(JSON.stringify(JSON.parse(require('fs').readFileSync(0,'utf8')), null, 2))"
+
+echo ""
+echo "=== POST round (OA, pending) ==="
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"round_type":"oa","result":"pending","notes":"API smoke test"}' \
+  "$API/opportunities/$OPP_ID/rounds" | node -e "console.log(JSON.stringify(JSON.parse(require('fs').readFileSync(0,'utf8')), null, 2))"
+
+echo ""
+echo "=== GET rounds (after create) ==="
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$API/opportunities/$OPP_ID/rounds" | node -e "console.log(JSON.stringify(JSON.parse(require('fs').readFileSync(0,'utf8')), null, 2))"
+
+echo ""
+echo "Done."

--- a/src/components/opportunities/OpportunityCard.jsx
+++ b/src/components/opportunities/OpportunityCard.jsx
@@ -6,11 +6,11 @@
  * Edit/Delete buttons remain for quick actions.
  */
 import React from 'react';
-import { FaEdit, FaTrash, FaExternalLinkAlt } from 'react-icons/fa';
+import { FaEdit, FaTrash, FaExternalLinkAlt, FaLayerGroup } from 'react-icons/fa';
 import Card from '../common/Card';
 import Button from '../common/Button';
 import { getDaysRemaining, isOverdue, formatDate } from '../../utils/dateHelpers';
-import { getRoundSummaryLabel } from '../../utils/roundHelpers';
+import { getRoundSummaryLabel, getRoundSummaryStyle } from '../../utils/roundHelpers';
 
 // Status badge color mappings
 const statusColors = {
@@ -104,7 +104,10 @@ const OpportunityCard = ({ opportunity, onView, onEdit, onDelete }) => {
               {opportunity.status.charAt(0).toUpperCase() + opportunity.status.slice(1)}
             </span>
             {roundSummary && (
-              <span className="inline-block px-3 py-1 rounded-full text-xs font-medium bg-purple-500/10 text-purple-300 border border-purple-500/20">
+              <span
+                className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border ${getRoundSummaryStyle(opportunity)}`}
+              >
+                <FaLayerGroup size={10} aria-hidden="true" />
                 {roundSummary}
               </span>
             )}

--- a/src/components/opportunities/OpportunityCard.jsx
+++ b/src/components/opportunities/OpportunityCard.jsx
@@ -10,6 +10,7 @@ import { FaEdit, FaTrash, FaExternalLinkAlt } from 'react-icons/fa';
 import Card from '../common/Card';
 import Button from '../common/Button';
 import { getDaysRemaining, isOverdue, formatDate } from '../../utils/dateHelpers';
+import { getRoundSummaryLabel } from '../../utils/roundHelpers';
 
 // Status badge color mappings
 const statusColors = {
@@ -36,6 +37,7 @@ const categoryColors = {
 const OpportunityCard = ({ opportunity, onView, onEdit, onDelete }) => {
   const daysRemaining = getDaysRemaining(opportunity.deadline);
   const overdue = isOverdue(opportunity.deadline);
+  const roundSummary = getRoundSummaryLabel(opportunity);
 
   const handleCardClick = () => {
     if (onView) {
@@ -94,13 +96,18 @@ const OpportunityCard = ({ opportunity, onView, onEdit, onDelete }) => {
           </div>
 
           {/* Status Badge */}
-          <div className="mb-4">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
             <span
               className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${statusColors[opportunity.status] || 'bg-gray-500/10 text-gray-400 border border-gray-500/20'
                 }`}
             >
               {opportunity.status.charAt(0).toUpperCase() + opportunity.status.slice(1)}
             </span>
+            {roundSummary && (
+              <span className="inline-block px-3 py-1 rounded-full text-xs font-medium bg-purple-500/10 text-purple-300 border border-purple-500/20">
+                {roundSummary}
+              </span>
+            )}
           </div>
 
           {/* External Link */}

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -27,12 +27,13 @@ import {
     FaLayerGroup,
 } from 'react-icons/fa';
 import Button from '../common/Button';
-import RoundTimeline from '../rounds/RoundTimeline';
+import RoundTimeline, { RoundTimelineSkeleton } from '../rounds/RoundTimeline';
 import AddRoundModal from '../rounds/AddRoundModal';
 import { getDaysRemaining, isOverdue, formatDate } from '../../utils/dateHelpers';
 import { supportsDocuments } from '../../utils/opportunityHelpers';
 import {
     getNextRoundNumber,
+    getRoundProgressStats,
     supportsInterviewRounds,
 } from '../../utils/roundHelpers';
 import { documentService, roundService } from '../../services/api';
@@ -87,6 +88,7 @@ const OpportunityDetailModal = ({
     const [roundModalOpen, setRoundModalOpen] = useState(false);
     const [editingRound, setEditingRound] = useState(null);
     const [roundSaving, setRoundSaving] = useState(false);
+    const [deletingRoundId, setDeletingRoundId] = useState(null);
 
     useEffect(() => {
         setDisplayOpportunity(opportunity);
@@ -179,6 +181,8 @@ const OpportunityDetailModal = ({
         }
     }, [onOpportunityUpdated]);
 
+    const roundStats = getRoundProgressStats(rounds);
+
     if (!isOpen || !displayOpportunity) return null;
 
     const daysRemaining = getDaysRemaining(displayOpportunity.deadline);
@@ -223,15 +227,16 @@ const OpportunityDetailModal = ({
     };
 
     const handleDeleteRound = async (round) => {
-        if (!window.confirm(`Delete Round ${round.round_number}?`)) return;
-
         try {
+            setDeletingRoundId(round.id);
             const result = await roundService.delete(displayOpportunity.id, round.id);
             applyRoundMutationResult(result);
             toast.success('Round deleted');
         } catch (error) {
             console.error('Error deleting round:', error);
             toast.error(error.response?.data?.error || 'Failed to delete round');
+        } finally {
+            setDeletingRoundId(null);
         }
     };
 
@@ -260,6 +265,12 @@ const OpportunityDetailModal = ({
                                 <span className={`px-3 py-1 rounded-full text-xs font-medium ${statusColors[displayOpportunity.status] || 'bg-gray-500/10 text-gray-400 border border-gray-500/20'}`}>
                                     {displayOpportunity.status.charAt(0).toUpperCase() + displayOpportunity.status.slice(1)}
                                 </span>
+                                {roundStats.total > 0 && (
+                                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-purple-500/10 text-purple-300 border border-purple-500/20">
+                                        <FaLayerGroup size={10} aria-hidden="true" />
+                                        {roundStats.total} round{roundStats.total !== 1 ? 's' : ''}
+                                    </span>
+                                )}
                             </div>
                         </div>
                         <button
@@ -308,57 +319,52 @@ const OpportunityDetailModal = ({
                             </section>
                         )}
 
-                        {/* Attached Documents Section (Internships only) */}
+                        {/* Interview Pipeline (internships only) */}
                         {showInterviewRounds && (
                             <section>
-                                <div className="flex items-center justify-between gap-2 text-gray-400 mb-2">
-                                    <div className="flex items-center gap-2">
-                                        <FaLayerGroup size={14} />
-                                        <h3 className="text-sm font-medium uppercase tracking-wide">Interview Pipeline</h3>
+                                <div className="flex items-center justify-between gap-3 text-gray-400 mb-2">
+                                    <div className="flex items-center gap-2 min-w-0">
+                                        <FaLayerGroup size={14} className="shrink-0 text-purple-400" />
+                                        <div className="min-w-0">
+                                            <h3 className="text-sm font-medium uppercase tracking-wide text-gray-300">
+                                                Interview Pipeline
+                                            </h3>
+                                            {!roundsLoading && roundStats.total > 0 && (
+                                                <p className="text-xs text-gray-500 normal-case tracking-normal mt-0.5">
+                                                    {roundStats.total} round{roundStats.total !== 1 ? 's' : ''} logged
+                                                </p>
+                                            )}
+                                        </div>
                                     </div>
                                     <Button
                                         variant="outline"
                                         onClick={handleOpenAddRound}
-                                        className="!px-3 !py-1.5 text-xs"
+                                        disabled={roundsLoading || roundSaving}
+                                        className="!px-3 !py-1.5 text-xs shrink-0"
                                     >
                                         <FaPlus className="mr-1.5" size={12} />
                                         Add round
                                     </Button>
                                 </div>
-                                <div className="bg-white/5 rounded-lg p-4 border border-white/10">
+                                <div className="rounded-xl border border-white/10 bg-gradient-to-b from-white/[0.04] to-transparent p-4">
                                     {roundsLoading ? (
-                                        <div className="text-center text-gray-500 text-sm py-4">
-                                            <span className="animate-spin inline-block mr-2">⟳</span>
-                                            Loading rounds...
-                                        </div>
+                                        <RoundTimelineSkeleton />
                                     ) : (
-                                        <>
-                                            <RoundTimeline
-                                                rounds={rounds}
-                                                currentRoundNumber={displayOpportunity.current_round_number}
-                                                rejectedRoundNumber={displayOpportunity.rejected_round_number}
-                                                onEditRound={handleEditRound}
-                                            />
-                                            {rounds.length > 0 && (
-                                                <div className="mt-4 flex flex-wrap gap-2 border-t border-white/10 pt-4">
-                                                    {rounds.map((round) => (
-                                                        <button
-                                                            key={round.id}
-                                                            type="button"
-                                                            onClick={() => handleDeleteRound(round)}
-                                                            className="text-xs text-red-400 hover:text-red-300"
-                                                        >
-                                                            Delete Round {round.round_number}
-                                                        </button>
-                                                    ))}
-                                                </div>
-                                            )}
-                                        </>
+                                        <RoundTimeline
+                                            rounds={rounds}
+                                            currentRoundNumber={displayOpportunity.current_round_number}
+                                            rejectedRoundNumber={displayOpportunity.rejected_round_number}
+                                            onEditRound={handleEditRound}
+                                            onDeleteRound={handleDeleteRound}
+                                            onAddRound={handleOpenAddRound}
+                                            deletingRoundId={deletingRoundId}
+                                        />
                                     )}
                                 </div>
                             </section>
                         )}
 
+                        {/* Attached Documents Section (Internships only) */}
                         {supportsDocuments(displayOpportunity.category) && (
                             <section>
                                 <div className="flex items-center gap-2 text-gray-400 mb-2">

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -217,7 +217,9 @@ const OpportunityDetailModal = ({
             applyRoundMutationResult(result);
             setRoundModalOpen(false);
             setEditingRound(null);
-            toast.success(wasEditing ? 'Round updated' : 'Round added');
+            if (result?.opportunity?.status !== 'rejected') {
+                toast.success(wasEditing ? 'Round updated' : 'Round added');
+            }
         } catch (error) {
             console.error('Error saving round:', error);
             toast.error(error.response?.data?.error || 'Failed to save round');

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -35,7 +35,7 @@ import {
     getNextRoundNumber,
     supportsInterviewRounds,
 } from '../../utils/roundHelpers';
-import { documentService, opportunityService, roundService } from '../../services/api';
+import { documentService, roundService } from '../../services/api';
 
 // Status badge color mappings
 const statusColors = {
@@ -91,17 +91,6 @@ const OpportunityDetailModal = ({
     useEffect(() => {
         setDisplayOpportunity(opportunity);
     }, [opportunity]);
-
-    const refreshOpportunityAndRounds = useCallback(async (opportunityId) => {
-        const [freshOpportunity, freshRounds] = await Promise.all([
-            opportunityService.getById(opportunityId),
-            roundService.list(opportunityId),
-        ]);
-        setDisplayOpportunity(freshOpportunity);
-        setRounds(freshRounds);
-        onOpportunityUpdated?.(freshOpportunity);
-        return { freshOpportunity, freshRounds };
-    }, [onOpportunityUpdated]);
 
     // Fetch attached documents for internships
     useEffect(() => {
@@ -202,19 +191,29 @@ const OpportunityDetailModal = ({
         setEditingRound(null);
     };
 
+    const applyRoundMutationResult = useCallback((result) => {
+        if (result?.opportunity) {
+            setDisplayOpportunity(result.opportunity);
+            onOpportunityUpdated?.(result.opportunity);
+        }
+        if (result?.rounds) {
+            setRounds(result.rounds);
+        }
+    }, [onOpportunityUpdated]);
+
     const handleRoundSubmit = async (payload) => {
+        const wasEditing = Boolean(editingRound);
+
         try {
             setRoundSaving(true);
-            if (editingRound) {
-                await roundService.update(displayOpportunity.id, editingRound.id, payload);
-                toast.success('Round updated');
-            } else {
-                await roundService.create(displayOpportunity.id, payload);
-                toast.success('Round added');
-            }
-            await refreshOpportunityAndRounds(displayOpportunity.id);
+            const result = wasEditing
+                ? await roundService.update(displayOpportunity.id, editingRound.id, payload)
+                : await roundService.create(displayOpportunity.id, payload);
+
+            applyRoundMutationResult(result);
             setRoundModalOpen(false);
             setEditingRound(null);
+            toast.success(wasEditing ? 'Round updated' : 'Round added');
         } catch (error) {
             console.error('Error saving round:', error);
             toast.error(error.response?.data?.error || 'Failed to save round');
@@ -227,9 +226,9 @@ const OpportunityDetailModal = ({
         if (!window.confirm(`Delete Round ${round.round_number}?`)) return;
 
         try {
-            await roundService.delete(displayOpportunity.id, round.id);
+            const result = await roundService.delete(displayOpportunity.id, round.id);
+            applyRoundMutationResult(result);
             toast.success('Round deleted');
-            await refreshOpportunityAndRounds(displayOpportunity.id);
         } catch (error) {
             console.error('Error deleting round:', error);
             toast.error(error.response?.data?.error || 'Failed to delete round');

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -8,7 +8,7 @@
  * - Fixed footer with Edit/Delete actions
  * - Responsive: drawer layout on all devices
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import {
     FaTimes,
@@ -22,12 +22,20 @@ import {
     FaLink,
     FaFile,
     FaDownload,
-    FaUsers
+    FaUsers,
+    FaPlus,
+    FaLayerGroup,
 } from 'react-icons/fa';
 import Button from '../common/Button';
+import RoundTimeline from '../rounds/RoundTimeline';
+import AddRoundModal from '../rounds/AddRoundModal';
 import { getDaysRemaining, isOverdue, formatDate } from '../../utils/dateHelpers';
 import { supportsDocuments } from '../../utils/opportunityHelpers';
-import { documentService } from '../../services/api';
+import {
+    getNextRoundNumber,
+    supportsInterviewRounds,
+} from '../../utils/roundHelpers';
+import { documentService, opportunityService, roundService } from '../../services/api';
 
 // Status badge color mappings
 const statusColors = {
@@ -60,10 +68,40 @@ const documentTypeConfig = {
  * @param {Function} props.onEdit - Callback when Edit is clicked (receives opportunity.id)
  * @param {Function} props.onDelete - Callback when Delete is clicked (receives opportunity.id)
  * @param {Function} props.onManage - Callback when Manage is clicked for hackathons (receives opportunity.id)
+ * @param {Function} props.onOpportunityUpdated - Callback when opportunity fields change (e.g. after round sync)
  */
-const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete, onManage }) => {
+const OpportunityDetailModal = ({
+    opportunity,
+    isOpen,
+    onClose,
+    onEdit,
+    onDelete,
+    onManage,
+    onOpportunityUpdated,
+}) => {
+    const [displayOpportunity, setDisplayOpportunity] = useState(opportunity);
     const [documents, setDocuments] = useState([]);
     const [loadingDocs, setLoadingDocs] = useState(false);
+    const [rounds, setRounds] = useState([]);
+    const [roundsLoading, setRoundsLoading] = useState(false);
+    const [roundModalOpen, setRoundModalOpen] = useState(false);
+    const [editingRound, setEditingRound] = useState(null);
+    const [roundSaving, setRoundSaving] = useState(false);
+
+    useEffect(() => {
+        setDisplayOpportunity(opportunity);
+    }, [opportunity]);
+
+    const refreshOpportunityAndRounds = useCallback(async (opportunityId) => {
+        const [freshOpportunity, freshRounds] = await Promise.all([
+            opportunityService.getById(opportunityId),
+            roundService.list(opportunityId),
+        ]);
+        setDisplayOpportunity(freshOpportunity);
+        setRounds(freshRounds);
+        onOpportunityUpdated?.(freshOpportunity);
+        return { freshOpportunity, freshRounds };
+    }, [onOpportunityUpdated]);
 
     // Fetch attached documents for internships
     useEffect(() => {
@@ -85,6 +123,36 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
         } else {
             setDocuments([]);
         }
+    }, [isOpen, opportunity?.id, opportunity?.category]);
+
+    useEffect(() => {
+        if (!isOpen || !opportunity?.id || !supportsInterviewRounds(opportunity.category)) {
+            setRounds([]);
+            return;
+        }
+
+        let cancelled = false;
+
+        const loadRounds = async () => {
+            try {
+                setRoundsLoading(true);
+                const data = await roundService.list(opportunity.id);
+                if (!cancelled) setRounds(data);
+            } catch (error) {
+                console.error('Error loading rounds:', error);
+                if (!cancelled) {
+                    setRounds([]);
+                    toast.error('Failed to load interview rounds');
+                }
+            } finally {
+                if (!cancelled) setRoundsLoading(false);
+            }
+        };
+
+        loadRounds();
+        return () => {
+            cancelled = true;
+        };
     }, [isOpen, opportunity?.id, opportunity?.category]);
 
     // Close on Escape key
@@ -112,10 +180,61 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
         };
     }, [isOpen]);
 
-    if (!isOpen || !opportunity) return null;
+    if (!isOpen || !displayOpportunity) return null;
 
-    const daysRemaining = getDaysRemaining(opportunity.deadline);
-    const overdue = isOverdue(opportunity.deadline);
+    const daysRemaining = getDaysRemaining(displayOpportunity.deadline);
+    const overdue = isOverdue(displayOpportunity.deadline);
+    const showInterviewRounds = supportsInterviewRounds(displayOpportunity.category);
+
+    const handleOpenAddRound = () => {
+        setEditingRound(null);
+        setRoundModalOpen(true);
+    };
+
+    const handleEditRound = (round) => {
+        setEditingRound(round);
+        setRoundModalOpen(true);
+    };
+
+    const handleCloseRoundModal = () => {
+        if (roundSaving) return;
+        setRoundModalOpen(false);
+        setEditingRound(null);
+    };
+
+    const handleRoundSubmit = async (payload) => {
+        try {
+            setRoundSaving(true);
+            if (editingRound) {
+                await roundService.update(displayOpportunity.id, editingRound.id, payload);
+                toast.success('Round updated');
+            } else {
+                await roundService.create(displayOpportunity.id, payload);
+                toast.success('Round added');
+            }
+            await refreshOpportunityAndRounds(displayOpportunity.id);
+            setRoundModalOpen(false);
+            setEditingRound(null);
+        } catch (error) {
+            console.error('Error saving round:', error);
+            toast.error(error.response?.data?.error || 'Failed to save round');
+        } finally {
+            setRoundSaving(false);
+        }
+    };
+
+    const handleDeleteRound = async (round) => {
+        if (!window.confirm(`Delete Round ${round.round_number}?`)) return;
+
+        try {
+            await roundService.delete(displayOpportunity.id, round.id);
+            toast.success('Round deleted');
+            await refreshOpportunityAndRounds(displayOpportunity.id);
+        } catch (error) {
+            console.error('Error deleting round:', error);
+            toast.error(error.response?.data?.error || 'Failed to delete round');
+        }
+    };
 
     return (
         <div className="fixed inset-0 z-50 overflow-hidden">
@@ -133,14 +252,14 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                     <div className="flex items-start justify-between p-6 border-b border-white/10">
                         <div className="flex-1 pr-4">
                             <h2 className="text-xl font-bold text-white mb-3">
-                                {opportunity.title}
+                                {displayOpportunity.title}
                             </h2>
                             <div className="flex flex-wrap gap-2">
-                                <span className={`px-3 py-1 rounded-full text-xs font-medium ${categoryColors[opportunity.category] || 'bg-gray-500/10 text-gray-400 border border-gray-500/20'}`}>
-                                    {opportunity.category.charAt(0).toUpperCase() + opportunity.category.slice(1)}
+                                <span className={`px-3 py-1 rounded-full text-xs font-medium ${categoryColors[displayOpportunity.category] || 'bg-gray-500/10 text-gray-400 border border-gray-500/20'}`}>
+                                    {displayOpportunity.category.charAt(0).toUpperCase() + displayOpportunity.category.slice(1)}
                                 </span>
-                                <span className={`px-3 py-1 rounded-full text-xs font-medium ${statusColors[opportunity.status] || 'bg-gray-500/10 text-gray-400 border border-gray-500/20'}`}>
-                                    {opportunity.status.charAt(0).toUpperCase() + opportunity.status.slice(1)}
+                                <span className={`px-3 py-1 rounded-full text-xs font-medium ${statusColors[displayOpportunity.status] || 'bg-gray-500/10 text-gray-400 border border-gray-500/20'}`}>
+                                    {displayOpportunity.status.charAt(0).toUpperCase() + displayOpportunity.status.slice(1)}
                                 </span>
                             </div>
                         </div>
@@ -164,7 +283,7 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                             </div>
                             <div className="bg-white/5 rounded-lg p-4 border border-white/10">
                                 <p className="text-white font-medium">
-                                    {formatDate(opportunity.deadline)}
+                                    {formatDate(displayOpportunity.deadline)}
                                 </p>
                                 <p className={`text-sm mt-1 ${overdue ? 'text-red-400' : 'text-gray-400'}`}>
                                     {overdue
@@ -176,7 +295,7 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                         </section>
 
                         {/* Description Section */}
-                        {opportunity.description && (
+                        {displayOpportunity.description && (
                             <section>
                                 <div className="flex items-center gap-2 text-gray-400 mb-2">
                                     <FaFileAlt size={14} />
@@ -184,14 +303,64 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                                 </div>
                                 <div className="bg-white/5 rounded-lg p-4 border border-white/10">
                                     <p className="text-gray-300 whitespace-pre-wrap leading-relaxed">
-                                        {opportunity.description}
+                                        {displayOpportunity.description}
                                     </p>
                                 </div>
                             </section>
                         )}
 
                         {/* Attached Documents Section (Internships only) */}
-                        {supportsDocuments(opportunity.category) && (
+                        {showInterviewRounds && (
+                            <section>
+                                <div className="flex items-center justify-between gap-2 text-gray-400 mb-2">
+                                    <div className="flex items-center gap-2">
+                                        <FaLayerGroup size={14} />
+                                        <h3 className="text-sm font-medium uppercase tracking-wide">Interview Pipeline</h3>
+                                    </div>
+                                    <Button
+                                        variant="outline"
+                                        onClick={handleOpenAddRound}
+                                        className="!px-3 !py-1.5 text-xs"
+                                    >
+                                        <FaPlus className="mr-1.5" size={12} />
+                                        Add round
+                                    </Button>
+                                </div>
+                                <div className="bg-white/5 rounded-lg p-4 border border-white/10">
+                                    {roundsLoading ? (
+                                        <div className="text-center text-gray-500 text-sm py-4">
+                                            <span className="animate-spin inline-block mr-2">⟳</span>
+                                            Loading rounds...
+                                        </div>
+                                    ) : (
+                                        <>
+                                            <RoundTimeline
+                                                rounds={rounds}
+                                                currentRoundNumber={displayOpportunity.current_round_number}
+                                                rejectedRoundNumber={displayOpportunity.rejected_round_number}
+                                                onEditRound={handleEditRound}
+                                            />
+                                            {rounds.length > 0 && (
+                                                <div className="mt-4 flex flex-wrap gap-2 border-t border-white/10 pt-4">
+                                                    {rounds.map((round) => (
+                                                        <button
+                                                            key={round.id}
+                                                            type="button"
+                                                            onClick={() => handleDeleteRound(round)}
+                                                            className="text-xs text-red-400 hover:text-red-300"
+                                                        >
+                                                            Delete Round {round.round_number}
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </>
+                                    )}
+                                </div>
+                            </section>
+                        )}
+
+                        {supportsDocuments(displayOpportunity.category) && (
                             <section>
                                 <div className="flex items-center gap-2 text-gray-400 mb-2">
                                     <FaFilePdf size={14} />
@@ -244,7 +413,7 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                         )}
 
                         {/* Notes Section */}
-                        {opportunity.notes && (
+                        {displayOpportunity.notes && (
                             <section>
                                 <div className="flex items-center gap-2 text-gray-400 mb-2">
                                     <FaStickyNote size={14} />
@@ -252,21 +421,21 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                                 </div>
                                 <div className="bg-white/5 rounded-lg p-4 border border-white/10">
                                     <p className="text-gray-300 whitespace-pre-wrap leading-relaxed">
-                                        {opportunity.notes}
+                                        {displayOpportunity.notes}
                                     </p>
                                 </div>
                             </section>
                         )}
 
                         {/* External Link Section */}
-                        {opportunity.link && (
+                        {displayOpportunity.link && (
                             <section>
                                 <div className="flex items-center gap-2 text-gray-400 mb-2">
                                     <FaExternalLinkAlt size={14} />
                                     <h3 className="text-sm font-medium uppercase tracking-wide">Application Link</h3>
                                 </div>
                                 <a
-                                    href={opportunity.link}
+                                    href={displayOpportunity.link}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-white/5 border border-white/10 rounded-lg text-blue-400 hover:text-blue-300 hover:bg-white/10 transition-all"
@@ -281,10 +450,10 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                     {/* Fixed Footer with Actions */}
                     <div className="p-6 border-t border-white/10 bg-[#0A0A0A]">
                         <div className="flex gap-3">
-                            {opportunity.category === 'hackathon' && onManage && (
+                            {displayOpportunity.category === 'hackathon' && onManage && (
                                 <Button
                                     variant="secondary"
-                                    onClick={() => onManage(opportunity.id)}
+                                    onClick={() => onManage(displayOpportunity.id)}
                                     className="flex-1"
                                 >
                                     <FaUsers className="mr-2" size={14} />
@@ -293,7 +462,7 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                             )}
                             <Button
                                 variant="primary"
-                                onClick={() => onEdit(opportunity.id)}
+                                onClick={() => onEdit(displayOpportunity.id)}
                                 className="flex-1"
                             >
                                 <FaEdit className="mr-2" size={14} />
@@ -301,7 +470,7 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                             </Button>
                             <Button
                                 variant="danger"
-                                onClick={() => onDelete(opportunity.id)}
+                                onClick={() => onDelete(displayOpportunity.id)}
                                 className="flex-1"
                             >
                                 <FaTrash className="mr-2" size={14} />
@@ -311,6 +480,15 @@ const OpportunityDetailModal = ({ opportunity, isOpen, onClose, onEdit, onDelete
                     </div>
                 </div>
             </div>
+
+            <AddRoundModal
+                isOpen={roundModalOpen}
+                onClose={handleCloseRoundModal}
+                onSubmit={handleRoundSubmit}
+                roundNumber={getNextRoundNumber(rounds)}
+                initialRound={editingRound}
+                saving={roundSaving}
+            />
         </div>
     );
 };

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -169,6 +169,16 @@ const OpportunityDetailModal = ({
         };
     }, [isOpen]);
 
+    const applyRoundMutationResult = useCallback((result) => {
+        if (result?.opportunity) {
+            setDisplayOpportunity(result.opportunity);
+            onOpportunityUpdated?.(result.opportunity);
+        }
+        if (result?.rounds) {
+            setRounds(result.rounds);
+        }
+    }, [onOpportunityUpdated]);
+
     if (!isOpen || !displayOpportunity) return null;
 
     const daysRemaining = getDaysRemaining(displayOpportunity.deadline);
@@ -190,16 +200,6 @@ const OpportunityDetailModal = ({
         setRoundModalOpen(false);
         setEditingRound(null);
     };
-
-    const applyRoundMutationResult = useCallback((result) => {
-        if (result?.opportunity) {
-            setDisplayOpportunity(result.opportunity);
-            onOpportunityUpdated?.(result.opportunity);
-        }
-        if (result?.rounds) {
-            setRounds(result.rounds);
-        }
-    }, [onOpportunityUpdated]);
 
     const handleRoundSubmit = async (payload) => {
         const wasEditing = Boolean(editingRound);

--- a/src/components/rounds/AddRoundModal.jsx
+++ b/src/components/rounds/AddRoundModal.jsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
+import { ButtonSpinner } from '../common/LoadingSpinner';
 import {
   ROUND_RESULTS,
   ROUND_TYPES,
   ROUND_RESULT_LABELS,
   ROUND_TYPE_LABELS,
+  ROUND_RESULT_HINTS,
+  NOTES_MAX_LENGTH,
 } from '../../utils/roundHelpers';
 
 const emptyForm = {
@@ -14,6 +17,16 @@ const emptyForm = {
   result: 'pending',
   notes: '',
 };
+
+const RESULT_BUTTON_STYLES = {
+  pending: 'border-blue-500/40 bg-blue-500/15 text-blue-300 ring-1 ring-blue-500/30',
+  cleared: 'border-green-500/40 bg-green-500/15 text-green-300 ring-1 ring-green-500/30',
+  rejected: 'border-red-500/40 bg-red-500/15 text-red-300 ring-1 ring-red-500/30',
+  skipped: 'border-gray-500/40 bg-gray-500/15 text-gray-300 ring-1 ring-gray-500/30',
+};
+
+const RESULT_IDLE_STYLES =
+  'border-white/10 bg-white/5 text-gray-400 hover:border-white/20 hover:bg-white/10 hover:text-gray-300';
 
 /**
  * Create or edit an interview round.
@@ -48,6 +61,11 @@ const AddRoundModal = ({
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
   };
 
+  const handleResultSelect = (result) => {
+    if (saving) return;
+    setForm((prev) => ({ ...prev, result }));
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     const payload = {
@@ -63,9 +81,22 @@ const AddRoundModal = ({
     ? `Edit Round ${initialRound.round_number}`
     : `Add Round ${roundNumber}`;
 
+  const notesLength = form.notes.length;
+
+  const handleClose = () => {
+    if (saving) return;
+    onClose();
+  };
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={title}>
-      <form onSubmit={handleSubmit} className="space-y-4">
+    <Modal isOpen={isOpen} onClose={handleClose} title={title}>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <p className="text-sm text-gray-400 -mt-1">
+          {isEdit
+            ? 'Update details or mark the outcome when you hear back.'
+            : 'Log the next step in your hiring pipeline.'}
+        </p>
+
         <div>
           <label htmlFor="round_type" className="mb-1.5 block text-sm font-medium text-gray-300">
             Round type
@@ -74,7 +105,8 @@ const AddRoundModal = ({
             id="round_type"
             value={form.round_type}
             onChange={handleChange('round_type')}
-            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none"
+            disabled={saving}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 disabled:opacity-60"
             required
           >
             {ROUND_TYPES.map((type) => (
@@ -87,56 +119,76 @@ const AddRoundModal = ({
 
         <div>
           <label htmlFor="scheduled_date" className="mb-1.5 block text-sm font-medium text-gray-300">
-            Scheduled date (optional)
+            Scheduled date
+            <span className="ml-1 font-normal text-gray-500">(optional)</span>
           </label>
           <input
             id="scheduled_date"
             type="date"
             value={form.scheduled_date}
             onChange={handleChange('scheduled_date')}
-            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none"
+            disabled={saving}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 disabled:opacity-60 [color-scheme:dark]"
           />
         </div>
 
-        <div>
-          <label htmlFor="result" className="mb-1.5 block text-sm font-medium text-gray-300">
-            Result
-          </label>
-          <select
-            id="result"
-            value={form.result}
-            onChange={handleChange('result')}
-            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none"
-            required
-          >
+        <fieldset disabled={saving}>
+          <legend className="mb-2 block text-sm font-medium text-gray-300">Result</legend>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
             {ROUND_RESULTS.map((result) => (
-              <option key={result} value={result} style={{ backgroundColor: '#111827' }}>
+              <button
+                key={result}
+                type="button"
+                onClick={() => handleResultSelect(result)}
+                className={`rounded-lg border px-2 py-2.5 text-xs font-medium transition-all ${
+                  form.result === result ? RESULT_BUTTON_STYLES[result] : RESULT_IDLE_STYLES
+                }`}
+                aria-pressed={form.result === result}
+              >
                 {ROUND_RESULT_LABELS[result]}
-              </option>
+              </button>
             ))}
-          </select>
-        </div>
+          </div>
+          <p className="mt-2 text-xs text-gray-500">{ROUND_RESULT_HINTS[form.result]}</p>
+        </fieldset>
 
         <div>
-          <label htmlFor="notes" className="mb-1.5 block text-sm font-medium text-gray-300">
-            Notes (optional)
-          </label>
+          <div className="mb-1.5 flex items-center justify-between">
+            <label htmlFor="notes" className="text-sm font-medium text-gray-300">
+              Notes
+              <span className="ml-1 font-normal text-gray-500">(optional)</span>
+            </label>
+            <span className={`text-xs ${notesLength > NOTES_MAX_LENGTH ? 'text-red-400' : 'text-gray-500'}`}>
+              {notesLength}/{NOTES_MAX_LENGTH}
+            </span>
+          </div>
           <textarea
             id="notes"
             value={form.notes}
             onChange={handleChange('notes')}
+            maxLength={NOTES_MAX_LENGTH}
             rows={3}
-            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none resize-none"
+            disabled={saving}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 resize-none disabled:opacity-60"
             placeholder="Prep topics, interviewer names, feedback..."
           />
         </div>
 
-        <div className="flex justify-end gap-3 pt-2">
-          <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
+        <div className="flex justify-end gap-3 border-t border-white/10 pt-4">
+          <Button type="button" variant="secondary" onClick={handleClose} disabled={saving}>
             Cancel
           </Button>
-          <Button type="submit" variant="primary" disabled={saving}>
-            {saving ? 'Saving...' : isEdit ? 'Save changes' : 'Add round'}
+          <Button type="submit" variant="primary" disabled={saving || notesLength > NOTES_MAX_LENGTH}>
+            {saving ? (
+              <span className="inline-flex items-center gap-2">
+                <ButtonSpinner />
+                Saving…
+              </span>
+            ) : isEdit ? (
+              'Save changes'
+            ) : (
+              'Add round'
+            )}
           </Button>
         </div>
       </form>

--- a/src/components/rounds/AddRoundModal.jsx
+++ b/src/components/rounds/AddRoundModal.jsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useState } from 'react';
+import Modal from '../common/Modal';
+import Button from '../common/Button';
+import {
+  ROUND_RESULTS,
+  ROUND_TYPES,
+  ROUND_RESULT_LABELS,
+  ROUND_TYPE_LABELS,
+} from '../../utils/roundHelpers';
+
+const emptyForm = {
+  round_type: 'oa',
+  scheduled_date: '',
+  result: 'pending',
+  notes: '',
+};
+
+/**
+ * Create or edit an interview round.
+ */
+const AddRoundModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  roundNumber,
+  initialRound = null,
+  saving = false,
+}) => {
+  const [form, setForm] = useState(emptyForm);
+  const isEdit = Boolean(initialRound);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (initialRound) {
+      setForm({
+        round_type: initialRound.round_type || 'oa',
+        scheduled_date: initialRound.scheduled_date || '',
+        result: initialRound.result || 'pending',
+        notes: initialRound.notes || '',
+      });
+    } else {
+      setForm(emptyForm);
+    }
+  }, [isOpen, initialRound]);
+
+  const handleChange = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const payload = {
+      round_type: form.round_type,
+      result: form.result,
+      notes: form.notes.trim() || null,
+      scheduled_date: form.scheduled_date || null,
+    };
+    await onSubmit(payload);
+  };
+
+  const title = isEdit
+    ? `Edit Round ${initialRound.round_number}`
+    : `Add Round ${roundNumber}`;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="round_type" className="mb-1.5 block text-sm font-medium text-gray-300">
+            Round type
+          </label>
+          <select
+            id="round_type"
+            value={form.round_type}
+            onChange={handleChange('round_type')}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none"
+            required
+          >
+            {ROUND_TYPES.map((type) => (
+              <option key={type} value={type} style={{ backgroundColor: '#111827' }}>
+                {ROUND_TYPE_LABELS[type]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="scheduled_date" className="mb-1.5 block text-sm font-medium text-gray-300">
+            Scheduled date (optional)
+          </label>
+          <input
+            id="scheduled_date"
+            type="date"
+            value={form.scheduled_date}
+            onChange={handleChange('scheduled_date')}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="result" className="mb-1.5 block text-sm font-medium text-gray-300">
+            Result
+          </label>
+          <select
+            id="result"
+            value={form.result}
+            onChange={handleChange('result')}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none"
+            required
+          >
+            {ROUND_RESULTS.map((result) => (
+              <option key={result} value={result} style={{ backgroundColor: '#111827' }}>
+                {ROUND_RESULT_LABELS[result]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="notes" className="mb-1.5 block text-sm font-medium text-gray-300">
+            Notes (optional)
+          </label>
+          <textarea
+            id="notes"
+            value={form.notes}
+            onChange={handleChange('notes')}
+            rows={3}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-white focus:border-blue-500 focus:outline-none resize-none"
+            placeholder="Prep topics, interviewer names, feedback..."
+          />
+        </div>
+
+        <div className="flex justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" disabled={saving}>
+            {saving ? 'Saving...' : isEdit ? 'Save changes' : 'Add round'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default AddRoundModal;

--- a/src/components/rounds/RoundTimeline.jsx
+++ b/src/components/rounds/RoundTimeline.jsx
@@ -1,7 +1,24 @@
-import React from 'react';
-import { FaCheckCircle, FaClock, FaTimesCircle, FaForward } from 'react-icons/fa';
-import { formatDate } from '../../utils/dateHelpers';
+import React, { useState } from 'react';
 import {
+  FaCheckCircle,
+  FaClock,
+  FaTimesCircle,
+  FaForward,
+  FaEdit,
+  FaTrash,
+  FaLayerGroup,
+  FaPlus,
+  FaCode,
+  FaUsers,
+  FaClipboardList,
+  FaComments,
+  FaUserTie,
+  FaFlagCheckered,
+  FaEllipsisH,
+} from 'react-icons/fa';
+import { formatDate, getDaysRemaining } from '../../utils/dateHelpers';
+import {
+  getRoundProgressStats,
   getRoundResultLabel,
   getRoundTypeLabel,
   ROUND_RESULT_STYLES,
@@ -14,6 +31,104 @@ const RESULT_ICONS = {
   skipped: FaForward,
 };
 
+const ROUND_TYPE_ICONS = {
+  oa: FaClipboardList,
+  assignment: FaCode,
+  technical: FaCode,
+  hr: FaUserTie,
+  group_discussion: FaComments,
+  managerial: FaUsers,
+  final: FaFlagCheckered,
+  other: FaEllipsisH,
+};
+
+const connectorColor = (result) => {
+  if (result === 'cleared') return 'bg-green-500/40';
+  if (result === 'rejected') return 'bg-red-500/40';
+  if (result === 'skipped') return 'bg-gray-500/30';
+  return 'bg-white/10';
+};
+
+const nodeRingClass = (round, isActive) => {
+  if (round.result === 'rejected') {
+    return 'border-red-400/60 bg-red-500/15 shadow-[0_0_12px_rgba(248,113,113,0.15)]';
+  }
+  if (isActive) {
+    return 'border-blue-400 bg-blue-500/20 shadow-[0_0_14px_rgba(96,165,250,0.2)] animate-pulse';
+  }
+  if (round.result === 'cleared') {
+    return 'border-green-500/40 bg-green-500/10';
+  }
+  return 'border-white/20 bg-white/5';
+};
+
+const formatScheduledHint = (scheduledDate) => {
+  if (!scheduledDate) return null;
+  const days = getDaysRemaining(scheduledDate);
+  if (days === 0) return 'Today';
+  if (days === 1) return 'Tomorrow';
+  if (days > 1) return `In ${days} days`;
+  if (days === -1) return 'Yesterday';
+  return `${Math.abs(days)} days ago`;
+};
+
+export const RoundTimelineSkeleton = () => (
+  <div className="space-y-4 animate-pulse" aria-hidden="true">
+    <div className="h-2 bg-white/10 rounded-full w-full" />
+    <div className="flex gap-4">
+      <div className="h-8 w-8 rounded-full bg-white/10 shrink-0" />
+      <div className="flex-1 h-20 rounded-lg bg-white/10" />
+    </div>
+    <div className="flex gap-4">
+      <div className="h-8 w-8 rounded-full bg-white/10 shrink-0" />
+      <div className="flex-1 h-16 rounded-lg bg-white/10" />
+    </div>
+  </div>
+);
+
+const PipelineSummary = ({ rounds, currentRoundNumber, rejectedRoundNumber }) => {
+  const stats = getRoundProgressStats(rounds);
+
+  if (stats.total === 0) return null;
+
+  return (
+    <div className="mb-4 space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-400">
+        <span>
+          {stats.cleared} cleared
+          {stats.pending > 0 && ` · ${stats.pending} pending`}
+          {stats.skipped > 0 && ` · ${stats.skipped} skipped`}
+        </span>
+        <span className="font-medium text-gray-300">{stats.progressPercent}% complete</span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${
+            rejectedRoundNumber ? 'bg-red-500/70' : 'bg-gradient-to-r from-blue-500/80 to-green-500/80'
+          }`}
+          style={{ width: `${rejectedRoundNumber ? 100 : stats.progressPercent}%` }}
+        />
+      </div>
+      {rejectedRoundNumber ? (
+        <p className="text-sm text-red-300 flex items-center gap-2">
+          <FaTimesCircle className="shrink-0" size={14} />
+          Stopped at Round {rejectedRoundNumber}
+        </p>
+      ) : currentRoundNumber ? (
+        <p className="text-sm text-blue-200 flex items-center gap-2">
+          <FaClock className="shrink-0" size={14} />
+          Up next: Round {currentRoundNumber}
+        </p>
+      ) : stats.cleared === stats.total ? (
+        <p className="text-sm text-green-300 flex items-center gap-2">
+          <FaCheckCircle className="shrink-0" size={14} />
+          All recorded rounds cleared
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
 /**
  * Presentational vertical timeline for interview rounds.
  */
@@ -22,60 +137,82 @@ const RoundTimeline = ({
   currentRoundNumber = null,
   rejectedRoundNumber = null,
   onEditRound,
+  onDeleteRound,
+  onAddRound,
+  deletingRoundId = null,
 }) => {
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
   const sortedRounds = [...rounds].sort((a, b) => a.round_number - b.round_number);
 
   if (sortedRounds.length === 0) {
     return (
-      <div className="rounded-lg border border-dashed border-white/15 bg-white/5 p-4 text-center text-sm text-gray-400">
-        No rounds yet. Add your first round after applying.
+      <div className="rounded-xl border border-dashed border-white/15 bg-gradient-to-b from-white/[0.04] to-transparent px-5 py-8 text-center">
+        <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-purple-500/10 border border-purple-500/20">
+          <FaLayerGroup className="text-purple-400" size={20} />
+        </div>
+        <p className="text-sm font-medium text-white mb-1">No interview rounds yet</p>
+        <p className="text-xs text-gray-400 mb-4 max-w-[240px] mx-auto leading-relaxed">
+          Track OA, technical, HR, and final rounds as you move through the hiring process.
+        </p>
+        {onAddRound && (
+          <button
+            type="button"
+            onClick={onAddRound}
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-300 hover:bg-blue-500/20 hover:text-blue-200 transition-colors"
+          >
+            <FaPlus size={12} />
+            Add first round
+          </button>
+        )}
       </div>
     );
   }
 
-  const activePending = sortedRounds.find((round) => round.result === 'pending');
+  const handleDeleteClick = (round) => {
+    if (confirmDeleteId === round.id) {
+      onDeleteRound?.(round);
+      setConfirmDeleteId(null);
+      return;
+    }
+    setConfirmDeleteId(round.id);
+  };
 
   return (
-    <div className="space-y-4">
-      {rejectedRoundNumber && (
-        <div
-          className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300"
-          role="status"
-        >
-          Rejected at Round {rejectedRoundNumber}
-        </div>
-      )}
-
-      {!rejectedRoundNumber && activePending && (
-        <div
-          className="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm text-blue-200"
-          role="status"
-        >
-          Preparing for Round {activePending.round_number} · {getRoundTypeLabel(activePending.round_type)}
-        </div>
-      )}
+    <div className="space-y-1">
+      <PipelineSummary
+        rounds={sortedRounds}
+        currentRoundNumber={currentRoundNumber}
+        rejectedRoundNumber={rejectedRoundNumber}
+      />
 
       <ol className="space-y-0" aria-label="Interview rounds">
         {sortedRounds.map((round, index) => {
-          const Icon = RESULT_ICONS[round.result] || FaClock;
+          const ResultIcon = RESULT_ICONS[round.result] || FaClock;
+          const TypeIcon = ROUND_TYPE_ICONS[round.round_type] || FaEllipsisH;
           const isActive = currentRoundNumber === round.round_number;
           const isLast = index === sortedRounds.length - 1;
+          const scheduledHint = formatScheduledHint(round.scheduled_date);
+          const isDeleting = deletingRoundId === round.id;
+          const isConfirmingDelete = confirmDeleteId === round.id;
 
           return (
-            <li key={round.id} className="relative flex gap-4 pb-6 last:pb-0">
+            <li key={round.id} className="relative flex gap-3 pb-5 last:pb-0">
               {!isLast && (
                 <span
-                  className="absolute left-[15px] top-8 h-[calc(100%-1rem)] w-px bg-white/10"
+                  className={`absolute left-[15px] top-9 h-[calc(100%-0.75rem)] w-0.5 rounded-full ${connectorColor(
+                    round.result
+                  )}`}
                   aria-hidden="true"
                 />
               )}
 
               <div
-                className={`relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border ${
-                  isActive ? 'border-blue-400 bg-blue-500/20' : 'border-white/20 bg-white/5'
-                }`}
+                className={`relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 ${nodeRingClass(
+                  round,
+                  isActive
+                )}`}
               >
-                <Icon
+                <ResultIcon
                   className={
                     round.result === 'cleared'
                       ? 'text-green-400'
@@ -85,24 +222,49 @@ const RoundTimeline = ({
                           ? 'text-gray-400'
                           : 'text-blue-400'
                   }
-                  size={14}
+                  size={13}
+                  aria-hidden="true"
                 />
               </div>
 
-              <div className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 p-4">
-                <div className="flex flex-wrap items-start justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-semibold text-white">
-                      Round {round.round_number} · {getRoundTypeLabel(round.round_type)}
-                    </p>
+              <div
+                className={`min-w-0 flex-1 rounded-xl border p-4 transition-colors ${
+                  isActive
+                    ? 'border-blue-500/30 bg-blue-500/[0.07]'
+                    : round.result === 'rejected'
+                      ? 'border-red-500/20 bg-red-500/[0.04]'
+                      : 'border-white/10 bg-white/[0.04] hover:bg-white/[0.06]'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <TypeIcon className="text-gray-500 shrink-0" size={12} aria-hidden="true" />
+                      <p className="text-sm font-semibold text-white truncate">
+                        Round {round.round_number}
+                        <span className="font-normal text-gray-400"> · </span>
+                        {getRoundTypeLabel(round.round_type)}
+                      </p>
+                    </div>
                     {round.scheduled_date && (
-                      <p className="mt-1 text-xs text-gray-400">
-                        Scheduled {formatDate(round.scheduled_date)}
+                      <p className="text-xs text-gray-400 mt-1">
+                        {formatDate(round.scheduled_date)}
+                        {scheduledHint && (
+                          <span
+                            className={`ml-1.5 ${
+                              scheduledHint === 'Today' || scheduledHint === 'Tomorrow'
+                                ? 'text-amber-400 font-medium'
+                                : 'text-gray-500'
+                            }`}
+                          >
+                            ({scheduledHint})
+                          </span>
+                        )}
                       </p>
                     )}
                   </div>
                   <span
-                    className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+                    className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-medium ${
                       ROUND_RESULT_STYLES[round.result] ||
                       'bg-gray-500/10 text-gray-400 border-gray-500/20'
                     }`}
@@ -112,17 +274,60 @@ const RoundTimeline = ({
                 </div>
 
                 {round.notes && (
-                  <p className="mt-3 text-sm text-gray-300 whitespace-pre-wrap">{round.notes}</p>
+                  <p className="mt-3 text-sm text-gray-300 whitespace-pre-wrap leading-relaxed border-t border-white/5 pt-3">
+                    {round.notes}
+                  </p>
                 )}
 
-                {onEditRound && (
-                  <button
-                    type="button"
-                    onClick={() => onEditRound(round)}
-                    className="mt-3 text-xs font-medium text-blue-400 hover:text-blue-300"
-                  >
-                    Edit round
-                  </button>
+                {(onEditRound || onDeleteRound) && (
+                  <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-white/5 pt-3">
+                    {onEditRound && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setConfirmDeleteId(null);
+                          onEditRound(round);
+                        }}
+                        disabled={isDeleting}
+                        className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-blue-400 hover:bg-blue-500/10 hover:text-blue-300 transition-colors disabled:opacity-50"
+                      >
+                        <FaEdit size={11} />
+                        Edit
+                      </button>
+                    )}
+                    {onDeleteRound && (
+                      isConfirmingDelete ? (
+                        <span className="inline-flex items-center gap-2 text-xs">
+                          <span className="text-gray-400">Delete round?</span>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteClick(round)}
+                            disabled={isDeleting}
+                            className="font-medium text-red-400 hover:text-red-300 disabled:opacity-50"
+                          >
+                            {isDeleting ? 'Deleting…' : 'Yes, delete'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmDeleteId(null)}
+                            className="text-gray-400 hover:text-gray-300"
+                          >
+                            Cancel
+                          </button>
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteClick(round)}
+                          disabled={isDeleting}
+                          className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-400 hover:bg-red-500/10 hover:text-red-400 transition-colors disabled:opacity-50"
+                        >
+                          <FaTrash size={11} />
+                          Delete
+                        </button>
+                      )
+                    )}
+                  </div>
                 )}
               </div>
             </li>

--- a/src/components/rounds/RoundTimeline.jsx
+++ b/src/components/rounds/RoundTimeline.jsx
@@ -15,6 +15,8 @@ import {
   FaUserTie,
   FaFlagCheckered,
   FaEllipsisH,
+  FaFileAlt,
+  FaLaptopCode,
 } from 'react-icons/fa';
 import { formatDate, getDaysRemaining } from '../../utils/dateHelpers';
 import {
@@ -32,8 +34,10 @@ const RESULT_ICONS = {
 };
 
 const ROUND_TYPE_ICONS = {
+  resume_shortlisted: FaFileAlt,
   oa: FaClipboardList,
   assignment: FaCode,
+  technical_assignment: FaLaptopCode,
   technical: FaCode,
   hr: FaUserTie,
   group_discussion: FaComments,

--- a/src/components/rounds/RoundTimeline.jsx
+++ b/src/components/rounds/RoundTimeline.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { FaCheckCircle, FaClock, FaTimesCircle, FaForward } from 'react-icons/fa';
+import { formatDate } from '../../utils/dateHelpers';
+import {
+  getRoundResultLabel,
+  getRoundTypeLabel,
+  ROUND_RESULT_STYLES,
+} from '../../utils/roundHelpers';
+
+const RESULT_ICONS = {
+  pending: FaClock,
+  cleared: FaCheckCircle,
+  rejected: FaTimesCircle,
+  skipped: FaForward,
+};
+
+/**
+ * Presentational vertical timeline for interview rounds.
+ */
+const RoundTimeline = ({
+  rounds = [],
+  currentRoundNumber = null,
+  rejectedRoundNumber = null,
+  onEditRound,
+}) => {
+  const sortedRounds = [...rounds].sort((a, b) => a.round_number - b.round_number);
+
+  if (sortedRounds.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-white/15 bg-white/5 p-4 text-center text-sm text-gray-400">
+        No rounds yet. Add your first round after applying.
+      </div>
+    );
+  }
+
+  const activePending = sortedRounds.find((round) => round.result === 'pending');
+
+  return (
+    <div className="space-y-4">
+      {rejectedRoundNumber && (
+        <div
+          className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300"
+          role="status"
+        >
+          Rejected at Round {rejectedRoundNumber}
+        </div>
+      )}
+
+      {!rejectedRoundNumber && activePending && (
+        <div
+          className="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm text-blue-200"
+          role="status"
+        >
+          Preparing for Round {activePending.round_number} · {getRoundTypeLabel(activePending.round_type)}
+        </div>
+      )}
+
+      <ol className="space-y-0" aria-label="Interview rounds">
+        {sortedRounds.map((round, index) => {
+          const Icon = RESULT_ICONS[round.result] || FaClock;
+          const isActive = currentRoundNumber === round.round_number;
+          const isLast = index === sortedRounds.length - 1;
+
+          return (
+            <li key={round.id} className="relative flex gap-4 pb-6 last:pb-0">
+              {!isLast && (
+                <span
+                  className="absolute left-[15px] top-8 h-[calc(100%-1rem)] w-px bg-white/10"
+                  aria-hidden="true"
+                />
+              )}
+
+              <div
+                className={`relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border ${
+                  isActive ? 'border-blue-400 bg-blue-500/20' : 'border-white/20 bg-white/5'
+                }`}
+              >
+                <Icon
+                  className={
+                    round.result === 'cleared'
+                      ? 'text-green-400'
+                      : round.result === 'rejected'
+                        ? 'text-red-400'
+                        : round.result === 'skipped'
+                          ? 'text-gray-400'
+                          : 'text-blue-400'
+                  }
+                  size={14}
+                />
+              </div>
+
+              <div className="min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-white">
+                      Round {round.round_number} · {getRoundTypeLabel(round.round_type)}
+                    </p>
+                    {round.scheduled_date && (
+                      <p className="mt-1 text-xs text-gray-400">
+                        Scheduled {formatDate(round.scheduled_date)}
+                      </p>
+                    )}
+                  </div>
+                  <span
+                    className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+                      ROUND_RESULT_STYLES[round.result] ||
+                      'bg-gray-500/10 text-gray-400 border-gray-500/20'
+                    }`}
+                  >
+                    {getRoundResultLabel(round.result)}
+                  </span>
+                </div>
+
+                {round.notes && (
+                  <p className="mt-3 text-sm text-gray-300 whitespace-pre-wrap">{round.notes}</p>
+                )}
+
+                {onEditRound && (
+                  <button
+                    type="button"
+                    onClick={() => onEditRound(round)}
+                    className="mt-3 text-xs font-medium text-blue-400 hover:text-blue-300"
+                  >
+                    Edit round
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+export default RoundTimeline;

--- a/src/pages/InternshipList.jsx
+++ b/src/pages/InternshipList.jsx
@@ -17,13 +17,14 @@ import OpportunityDetailModal from '../components/opportunities/OpportunityDetai
 import Modal from '../components/common/Modal';
 import Button from '../components/common/Button';
 import { opportunityService } from '../services/api';
+import { isActiveInternshipStatus } from '../utils/opportunityHelpers';
 
 const InternshipList = () => {
   const navigate = useNavigate();
   const [opportunities, setOpportunities] = useState([]);
   const [filteredOpportunities, setFilteredOpportunities] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('active');
   const [loading, setLoading] = useState(true);
 
   // Modal states
@@ -74,7 +75,9 @@ const InternshipList = () => {
       );
     }
 
-    if (statusFilter !== 'all') {
+    if (statusFilter === 'active') {
+      filtered = filtered.filter((opp) => isActiveInternshipStatus(opp.status));
+    } else if (statusFilter !== 'all') {
       filtered = filtered.filter(opp => opp.status === statusFilter);
     }
 
@@ -94,6 +97,15 @@ const InternshipList = () => {
     setOpportunities((prev) =>
       prev.map((opp) => (opp.id === updatedOpportunity.id ? updatedOpportunity : opp))
     );
+
+    if (!isActiveInternshipStatus(updatedOpportunity.status)) {
+      setSelectedOpportunity(null);
+      if (updatedOpportunity.status === 'rejected') {
+        toast.info('Internship marked as rejected and removed from your active list.');
+      }
+      return;
+    }
+
     setSelectedOpportunity(updatedOpportunity);
   };
 
@@ -132,7 +144,7 @@ const InternshipList = () => {
 
   const clearFilters = () => {
     setSearchQuery('');
-    setStatusFilter('all');
+    setStatusFilter('active');
   };
 
   return (
@@ -184,6 +196,7 @@ const InternshipList = () => {
                 onChange={(e) => setStatusFilter(e.target.value)}
                 className="px-4 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all w-full sm:w-auto"
               >
+                <option value="active" style={{ backgroundColor: '#111827', color: 'white' }}>Active</option>
                 <option value="all" style={{ backgroundColor: '#111827', color: 'white' }}>All Statuses</option>
                 <option value="applied" style={{ backgroundColor: '#111827', color: 'white' }}>Applied</option>
                 <option value="shortlisted" style={{ backgroundColor: '#111827', color: 'white' }}>Shortlisted</option>
@@ -193,7 +206,7 @@ const InternshipList = () => {
                 <option value="ghosted" style={{ backgroundColor: '#111827', color: 'white' }}>Ghosted</option>
               </select>
 
-              {(searchQuery || statusFilter !== 'all') && (
+              {(searchQuery || statusFilter !== 'active') && (
                 <Button variant="secondary" onClick={clearFilters} className="w-full sm:w-auto">
                   Clear
                 </Button>
@@ -204,6 +217,7 @@ const InternshipList = () => {
           {/* Results Count */}
           <div className="mt-3 text-sm text-gray-400">
             Showing {filteredOpportunities.length} of {opportunities.length} internships
+            {statusFilter === 'active' && ' (active only)'}
           </div>
         </div>
 

--- a/src/pages/InternshipList.jsx
+++ b/src/pages/InternshipList.jsx
@@ -90,6 +90,13 @@ const InternshipList = () => {
     setSelectedOpportunity(null);
   };
 
+  const handleOpportunityUpdated = (updatedOpportunity) => {
+    setOpportunities((prev) =>
+      prev.map((opp) => (opp.id === updatedOpportunity.id ? updatedOpportunity : opp))
+    );
+    setSelectedOpportunity(updatedOpportunity);
+  };
+
   // Edit handler - closes detail modal and navigates to edit page
   const handleEdit = (id) => {
     setSelectedOpportunity(null);
@@ -222,6 +229,7 @@ const InternshipList = () => {
           onClose={handleCloseDetail}
           onEdit={handleEdit}
           onDelete={handleDeleteClick}
+          onOpportunityUpdated={handleOpportunityUpdated}
         />
 
         {/* Delete Confirmation Modal */}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -99,6 +99,33 @@ api.interceptors.response.use(
     }
 );
 
+export const roundService = {
+  list: async (opportunityId) => {
+    const response = await api.get(`/opportunities/${opportunityId}/rounds`);
+    return response.data;
+  },
+
+  create: async (opportunityId, roundData) => {
+    const response = await api.post(`/opportunities/${opportunityId}/rounds`, roundData);
+    return response.data;
+  },
+
+  update: async (opportunityId, roundId, roundData) => {
+    const response = await api.patch(
+      `/opportunities/${opportunityId}/rounds/${roundId}`,
+      roundData
+    );
+    return response.data;
+  },
+
+  delete: async (opportunityId, roundId) => {
+    const response = await api.delete(
+      `/opportunities/${opportunityId}/rounds/${roundId}`
+    );
+    return response.data;
+  },
+};
+
 export const opportunityService = {
     getAll: async () => {
         const response = await api.get('/opportunities');

--- a/src/utils/opportunityHelpers.js
+++ b/src/utils/opportunityHelpers.js
@@ -20,6 +20,12 @@ export const supportsDocuments = (category) => {
  */
 export const DOCUMENT_SUPPORTED_CATEGORIES = ['internship'];
 
+/** Internship statuses no longer in the active pipeline (hidden by default on Internships page). */
+export const INACTIVE_INTERNSHIP_STATUSES = ['rejected', 'selected', 'ghosted'];
+
+export const isActiveInternshipStatus = (status) =>
+  !INACTIVE_INTERNSHIP_STATUSES.includes(status);
+
 /**
  * Get a user-friendly message explaining why documents are not available
  * @param {string} category - The opportunity category

--- a/src/utils/opportunityHelpers.test.js
+++ b/src/utils/opportunityHelpers.test.js
@@ -2,6 +2,8 @@ import {
     supportsDocuments,
     DOCUMENT_SUPPORTED_CATEGORIES,
     getDocumentUnavailableMessage,
+    isActiveInternshipStatus,
+    INACTIVE_INTERNSHIP_STATUSES,
 } from './opportunityHelpers';
 
 describe('opportunityHelpers', () => {
@@ -28,6 +30,20 @@ describe('opportunityHelpers', () => {
 
         it('returns explanation when documents are not supported', () => {
             expect(getDocumentUnavailableMessage('hackathon')).toMatch(/internship/i);
+        });
+    });
+
+    describe('isActiveInternshipStatus', () => {
+        it('treats applied and interviewed as active', () => {
+            expect(isActiveInternshipStatus('applied')).toBe(true);
+            expect(isActiveInternshipStatus('interviewed')).toBe(true);
+            expect(isActiveInternshipStatus('shortlisted')).toBe(true);
+        });
+
+        it('treats rejected, selected, and ghosted as inactive', () => {
+            INACTIVE_INTERNSHIP_STATUSES.forEach((status) => {
+                expect(isActiveInternshipStatus(status)).toBe(false);
+            });
         });
     });
 });

--- a/src/utils/roundHelpers.js
+++ b/src/utils/roundHelpers.js
@@ -71,3 +71,39 @@ export const getNextRoundNumber = (rounds) => {
   if (!rounds?.length) return 1;
   return Math.max(...rounds.map((r) => r.round_number)) + 1;
 };
+
+export const NOTES_MAX_LENGTH = 5000;
+
+/**
+ * Aggregate stats for pipeline header / progress bar.
+ */
+export const getRoundProgressStats = (rounds = []) => {
+  const sorted = [...rounds].sort((a, b) => a.round_number - b.round_number);
+  const total = sorted.length;
+  const cleared = sorted.filter((r) => r.result === 'cleared').length;
+  const pending = sorted.filter((r) => r.result === 'pending').length;
+  const skipped = sorted.filter((r) => r.result === 'skipped').length;
+  const hasRejection = sorted.some((r) => r.result === 'rejected');
+  const completed = cleared + skipped;
+  const progressPercent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return { total, cleared, pending, skipped, hasRejection, completed, progressPercent };
+};
+
+/** Card badge Tailwind classes keyed off synced opportunity fields. */
+export const getRoundSummaryStyle = (opportunity) => {
+  if (opportunity?.rejected_round_number) {
+    return 'bg-red-500/10 text-red-300 border-red-500/20';
+  }
+  if (opportunity?.current_round_number) {
+    return 'bg-purple-500/10 text-purple-300 border-purple-500/20';
+  }
+  return 'bg-gray-500/10 text-gray-400 border-gray-500/20';
+};
+
+export const ROUND_RESULT_HINTS = {
+  pending: 'Scheduled or awaiting outcome',
+  cleared: 'Passed — you can add the next round',
+  rejected: 'Marks the pipeline as rejected',
+  skipped: 'Round was cancelled or not required',
+};

--- a/src/utils/roundHelpers.js
+++ b/src/utils/roundHelpers.js
@@ -3,8 +3,10 @@
  */
 
 export const ROUND_TYPES = [
+  'resume_shortlisted',
   'oa',
   'assignment',
+  'technical_assignment',
   'technical',
   'hr',
   'group_discussion',
@@ -16,8 +18,10 @@ export const ROUND_TYPES = [
 export const ROUND_RESULTS = ['pending', 'cleared', 'rejected', 'skipped'];
 
 export const ROUND_TYPE_LABELS = {
+  resume_shortlisted: 'Resume Shortlisted',
   oa: 'Online Assessment',
   assignment: 'Assignment',
+  technical_assignment: 'Technical Assignment',
   technical: 'Technical Interview',
   hr: 'HR Interview',
   group_discussion: 'Group Discussion',
@@ -104,6 +108,6 @@ export const getRoundSummaryStyle = (opportunity) => {
 export const ROUND_RESULT_HINTS = {
   pending: 'Scheduled or awaiting outcome',
   cleared: 'Passed — you can add the next round',
-  rejected: 'Marks the pipeline as rejected',
+  rejected: 'Marks the pipeline as rejected — internship moves out of your active list',
   skipped: 'Round was cancelled or not required',
 };

--- a/src/utils/roundHelpers.js
+++ b/src/utils/roundHelpers.js
@@ -1,0 +1,73 @@
+/**
+ * Interview round display helpers (aligned with backend rounds-schemas.js)
+ */
+
+export const ROUND_TYPES = [
+  'oa',
+  'assignment',
+  'technical',
+  'hr',
+  'group_discussion',
+  'managerial',
+  'final',
+  'other',
+];
+
+export const ROUND_RESULTS = ['pending', 'cleared', 'rejected', 'skipped'];
+
+export const ROUND_TYPE_LABELS = {
+  oa: 'Online Assessment',
+  assignment: 'Assignment',
+  technical: 'Technical Interview',
+  hr: 'HR Interview',
+  group_discussion: 'Group Discussion',
+  managerial: 'Managerial',
+  final: 'Final Round',
+  other: 'Other',
+};
+
+export const ROUND_RESULT_LABELS = {
+  pending: 'Pending',
+  cleared: 'Cleared',
+  rejected: 'Rejected',
+  skipped: 'Skipped',
+};
+
+export const ROUND_RESULT_STYLES = {
+  pending: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  cleared: 'bg-green-500/10 text-green-400 border-green-500/20',
+  rejected: 'bg-red-500/10 text-red-400 border-red-500/20',
+  skipped: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+};
+
+export const supportsInterviewRounds = (category) => category === 'internship';
+
+export const getRoundTypeLabel = (roundType) =>
+  ROUND_TYPE_LABELS[roundType] || roundType;
+
+export const getRoundResultLabel = (result) =>
+  ROUND_RESULT_LABELS[result] || result;
+
+/**
+ * Compact card label from synced opportunity fields.
+ */
+export const getRoundSummaryLabel = (opportunity) => {
+  if (!opportunity || !supportsInterviewRounds(opportunity.category)) {
+    return null;
+  }
+
+  if (opportunity.rejected_round_number) {
+    return `Rejected at Round ${opportunity.rejected_round_number}`;
+  }
+
+  if (opportunity.current_round_number) {
+    return `Round ${opportunity.current_round_number} · In progress`;
+  }
+
+  return null;
+};
+
+export const getNextRoundNumber = (rounds) => {
+  if (!rounds?.length) return 1;
+  return Math.max(...rounds.map((r) => r.round_number)) + 1;
+};


### PR DESCRIPTION
## Summary
- Adds `RoundTimeline` and `AddRoundModal` components for tracking multi-round internship interviews
- Wires `roundService` into the API client and integrates the pipeline into `OpportunityDetailModal` (internships only)
- Shows compact round progress on `OpportunityCard` and refreshes the internship list when rounds sync opportunity status

Closes #52, #53, #54. Part of epic #49 (depends on merged schema + API in #50/#51).

## Test plan
- [ ] Open an internship detail drawer → Interview Pipeline section loads
- [ ] Add a round (OA, technical, etc.) → timeline updates, status syncs to `interviewed`
- [ ] Mark a round rejected → opportunity status becomes `rejected`, card shows "Rejected at Round N"
- [ ] Edit and delete rounds → list and badges refresh without page reload
- [ ] `npm run test:ci` and `npm run check:architecture` pass
- [ ] `cd backend && npm test` pass (31 tests)