### PR TITLE
feat: optional on-campus / off-campus flag for opportunities

### DIFF
--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
         // Get all opportunities for the user with deadline included
         const { data: opportunities, error } = await supabase
             .from('opportunities')
-            .select('id, title, status, category, created_at, deadline, rejected_round_number, current_round_number')
+            .select('id, title, status, category, campus_mode, created_at, deadline, rejected_round_number, current_round_number')
             .eq('user_id', userId);
 
         if (error) throw error;
@@ -57,12 +57,25 @@ router.get('/', async (req, res) => {
             hackathon: 0
         };
 
+        const campusModeCounts = {
+            on_campus: 0,
+            off_campus: 0,
+            unspecified: 0
+        };
+
         opportunities.forEach(opp => {
             if (opp.status && statusCounts.hasOwnProperty(opp.status)) {
                 statusCounts[opp.status]++;
             }
             if (opp.category && categoryCounts.hasOwnProperty(opp.category)) {
                 categoryCounts[opp.category]++;
+            }
+            if (opp.campus_mode === 'on_campus') {
+                campusModeCounts.on_campus++;
+            } else if (opp.campus_mode === 'off_campus') {
+                campusModeCounts.off_campus++;
+            } else {
+                campusModeCounts.unspecified++;
             }
         });
 
@@ -155,6 +168,7 @@ router.get('/', async (req, res) => {
             total: totalApplied,
             statusCounts,
             categoryCounts,
+            campusModeCounts,
             metrics: {
                 conversionRate: conversionRate,
                 rejectionRate: rejectionRate,

--- a/backend/src/routes/opportunities.js
+++ b/backend/src/routes/opportunities.js
@@ -3,6 +3,7 @@ const { supabase } = require('../lib/supabase');
 const { validate } = require('../middleware/validate');
 const { createOpportunitySchema, updateOpportunitySchema, idParamSchema } = require('../validation/schemas');
 const opportunityRoundsRouter = require('./opportunity-rounds');
+const upcomingRoundsRouter = require('./upcoming-rounds');
 
 const router = express.Router();
 
@@ -72,7 +73,10 @@ router.get('/', async (req, res) => {
     }
 });
 
-// Interview rounds (must be registered before /:id to avoid route shadowing)
+// Upcoming rounds across all internships (before /:opportunityId/rounds)
+router.use('/rounds', upcomingRoundsRouter);
+
+// Interview rounds per opportunity (must be registered before /:id to avoid route shadowing)
 router.use('/:opportunityId/rounds', opportunityRoundsRouter);
 
 /**
@@ -109,7 +113,7 @@ router.get('/:id', async (req, res) => {
  */
 router.post('/', validate(createOpportunitySchema), async (req, res) => {
     try {
-        const { title, description, link, deadline, category, status, notes } = req.body;
+        const { title, description, link, deadline, category, status, notes, campus_mode } = req.body;
 
         const { data, error } = await supabase
             .from('opportunities')
@@ -121,7 +125,8 @@ router.post('/', validate(createOpportunitySchema), async (req, res) => {
                 deadline: deadline || null,
                 category: category || null,
                 status: status || 'applied',
-                notes: notes || null
+                notes: notes || null,
+                campus_mode: campus_mode || null
             })
             .select()
             .single();
@@ -145,7 +150,7 @@ router.post('/', validate(createOpportunitySchema), async (req, res) => {
 const updateHandler = async (req, res) => {
     try {
         const { id } = req.params;
-        const { title, description, link, deadline, category, status, notes } = req.body;
+        const { title, description, link, deadline, category, status, notes, campus_mode } = req.body;
 
         // Build update object with only provided fields
         const updateData = {};
@@ -156,6 +161,7 @@ const updateHandler = async (req, res) => {
         if (category !== undefined) updateData.category = category;
         if (status !== undefined) updateData.status = status;
         if (notes !== undefined) updateData.notes = notes;
+        if (campus_mode !== undefined) updateData.campus_mode = campus_mode || null;
 
         const { data, error } = await supabase
             .from('opportunities')

--- a/backend/src/routes/opportunities.js
+++ b/backend/src/routes/opportunities.js
@@ -3,7 +3,6 @@ const { supabase } = require('../lib/supabase');
 const { validate } = require('../middleware/validate');
 const { createOpportunitySchema, updateOpportunitySchema, idParamSchema } = require('../validation/schemas');
 const opportunityRoundsRouter = require('./opportunity-rounds');
-const upcomingRoundsRouter = require('./upcoming-rounds');
 
 const router = express.Router();
 
@@ -73,10 +72,7 @@ router.get('/', async (req, res) => {
     }
 });
 
-// Upcoming rounds across all internships (before /:opportunityId/rounds)
-router.use('/rounds', upcomingRoundsRouter);
-
-// Interview rounds per opportunity (must be registered before /:id to avoid route shadowing)
+// Interview rounds (must be registered before /:id to avoid route shadowing)
 router.use('/:opportunityId/rounds', opportunityRoundsRouter);
 
 /**

--- a/backend/src/validation/schemas.js
+++ b/backend/src/validation/schemas.js
@@ -67,6 +67,14 @@ const createOpportunitySchema = Joi.object({
         .optional()
         .messages({
             'string.max': 'Notes cannot exceed 5000 characters'
+        }),
+
+    campus_mode: Joi.string()
+        .valid('on_campus', 'off_campus')
+        .allow(null, '')
+        .optional()
+        .messages({
+            'any.only': 'Campus mode must be "on_campus" or "off_campus"'
         })
 });
 
@@ -136,6 +144,14 @@ const updateOpportunitySchema = Joi.object({
         .optional()
         .messages({
             'string.max': 'Notes cannot exceed 5000 characters'
+        }),
+
+    campus_mode: Joi.string()
+        .valid('on_campus', 'off_campus')
+        .allow(null, '')
+        .optional()
+        .messages({
+            'any.only': 'Campus mode must be "on_campus" or "off_campus"'
         })
 }).min(1).messages({
     'object.min': 'At least one field must be provided for update'

--- a/backend/tests/integration/analytics.test.js
+++ b/backend/tests/integration/analytics.test.js
@@ -1,0 +1,53 @@
+const { createChain } = require('../mocks/supabase');
+const { mockRequireAuth } = require('../mocks/auth');
+
+jest.mock('../../src/middleware/auth', () => ({
+    requireAuth: (...args) => mockRequireAuth(...args),
+}));
+
+const mockFrom = jest.fn();
+jest.mock('../../src/lib/supabase', () => ({
+    supabase: {
+        from: (...args) => mockFrom(...args),
+    },
+}));
+
+const request = require('supertest');
+const app = require('../../src/app');
+
+const authHeader = { Authorization: 'Bearer test-token' };
+
+describe('Analytics API', () => {
+    beforeEach(() => {
+        mockFrom.mockReset();
+    });
+
+    it('GET /api/analytics returns campusModeCounts', async () => {
+        const opportunities = [
+            { id: '1', title: 'A', status: 'applied', category: 'internship', campus_mode: 'on_campus', created_at: '2026-01-01', deadline: null },
+            { id: '2', title: 'B', status: 'applied', category: 'internship', campus_mode: 'off_campus', created_at: '2026-01-02', deadline: null },
+            { id: '3', title: 'C', status: 'applied', category: 'hackathon', campus_mode: null, created_at: '2026-01-03', deadline: null },
+        ];
+
+        mockFrom.mockImplementation((table) => {
+            if (table === 'opportunities') {
+                return createChain({ data: opportunities, error: null });
+            }
+            if (table === 'opportunity_rounds') {
+                return createChain({ data: [], error: null });
+            }
+            return createChain({ data: null, error: null });
+        });
+
+        const res = await request(app)
+            .get('/api/analytics')
+            .set(authHeader);
+
+        expect(res.status).toBe(200);
+        expect(res.body.campusModeCounts).toEqual({
+            on_campus: 1,
+            off_campus: 1,
+            unspecified: 1,
+        });
+    });
+});

--- a/backend/tests/integration/opportunities.test.js
+++ b/backend/tests/integration/opportunities.test.js
@@ -67,6 +67,72 @@ describe('Opportunities API', () => {
         expect(mockFrom).toHaveBeenCalledWith('opportunities');
     });
 
+    it('POST /api/opportunities accepts campus_mode', async () => {
+        const created = {
+            id: 'opp-2',
+            user_id: TEST_AUTH.internalUserId,
+            title: 'Campus Drive',
+            status: 'applied',
+            category: 'internship',
+            campus_mode: 'on_campus',
+        };
+
+        const chain = createChain({ data: created, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const res = await request(app)
+            .post('/api/opportunities')
+            .set(authHeader)
+            .send({
+                title: 'Campus Drive',
+                category: 'internship',
+                campus_mode: 'on_campus',
+            });
+
+        expect(res.status).toBe(201);
+        expect(res.body.campus_mode).toBe('on_campus');
+        expect(chain.insert).toHaveBeenCalledWith(
+            expect.objectContaining({ campus_mode: 'on_campus' })
+        );
+    });
+
+    it('POST /api/opportunities rejects invalid campus_mode', async () => {
+        const res = await request(app)
+            .post('/api/opportunities')
+            .set(authHeader)
+            .send({
+                title: 'Invalid Campus',
+                category: 'internship',
+                campus_mode: 'hybrid',
+            });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('Validation Error');
+        expect(res.body.details).toEqual(
+            expect.arrayContaining([expect.objectContaining({ field: 'campus_mode' })])
+        );
+    });
+
+    it('PATCH /api/opportunities/:id clears campus_mode', async () => {
+        const updated = {
+            id: '00000000-0000-4000-8000-000000000001',
+            user_id: TEST_AUTH.internalUserId,
+            title: 'Campus Drive',
+            campus_mode: null,
+        };
+
+        const chain = createChain({ data: updated, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const res = await request(app)
+            .patch('/api/opportunities/00000000-0000-4000-8000-000000000001')
+            .set(authHeader)
+            .send({ campus_mode: null });
+
+        expect(res.status).toBe(200);
+        expect(chain.update).toHaveBeenCalledWith({ campus_mode: null });
+    });
+
     it('PATCH /api/opportunities/:id returns 404 when not found', async () => {
         mockFrom.mockReturnValue(
             createChain({ data: null, error: { code: 'PGRST116', message: 'not found' } })

--- a/backend/tests/unit/validation.test.js
+++ b/backend/tests/unit/validation.test.js
@@ -48,6 +48,42 @@ describe('createOpportunitySchema', () => {
         });
         expect(error).toBeDefined();
     });
+
+    it('accepts valid campus_mode values', () => {
+        const onCampus = createOpportunitySchema.validate({
+            title: 'Campus Drive',
+            campus_mode: 'on_campus',
+        });
+        expect(onCampus.error).toBeUndefined();
+        expect(onCampus.value.campus_mode).toBe('on_campus');
+
+        const offCampus = createOpportunitySchema.validate({
+            title: 'Off-campus Role',
+            campus_mode: 'off_campus',
+        });
+        expect(offCampus.error).toBeUndefined();
+
+        const unset = createOpportunitySchema.validate({
+            title: 'Unspecified',
+            campus_mode: null,
+        });
+        expect(unset.error).toBeUndefined();
+
+        const empty = createOpportunitySchema.validate({
+            title: 'Empty campus mode',
+            campus_mode: '',
+        });
+        expect(empty.error).toBeUndefined();
+    });
+
+    it('rejects invalid campus_mode', () => {
+        const { error } = createOpportunitySchema.validate({
+            title: 'Test Role',
+            campus_mode: 'hybrid',
+        });
+        expect(error).toBeDefined();
+        expect(error.details[0].path).toContain('campus_mode');
+    });
 });
 
 describe('updateOpportunitySchema', () => {
@@ -55,6 +91,12 @@ describe('updateOpportunitySchema', () => {
         const { error, value } = updateOpportunitySchema.validate({ status: 'shortlisted' });
         expect(error).toBeUndefined();
         expect(value.status).toBe('shortlisted');
+    });
+
+    it('allows clearing campus_mode', () => {
+        const { error, value } = updateOpportunitySchema.validate({ campus_mode: null });
+        expect(error).toBeUndefined();
+        expect(value.campus_mode).toBeNull();
     });
 });
 

--- a/docs/opportunity-campus-mode-migration.sql
+++ b/docs/opportunity-campus-mode-migration.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- FutureTracker Campus Mode Migration
+-- Optional on-campus / off-campus flag for opportunities (#57)
+-- =============================================================================
+
+ALTER TABLE opportunities
+  ADD COLUMN IF NOT EXISTS campus_mode TEXT
+  CHECK (campus_mode IN ('on_campus', 'off_campus'));

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS opportunities (
   deadline DATE,
   category TEXT CHECK (category IN ('internship', 'hackathon')),
   status TEXT CHECK (status IN ('applied', 'interviewed', 'shortlisted', 'selected', 'rejected', 'ghosted')),
+  campus_mode TEXT CHECK (campus_mode IN ('on_campus', 'off_campus')),
   notes TEXT,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()

--- a/src/components/opportunities/CampusModeSelect.jsx
+++ b/src/components/opportunities/CampusModeSelect.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { CAMPUS_MODE_FILTER_OPTIONS } from '../../utils/opportunityHelpers';
+
+const selectClassName =
+  'px-4 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all w-full sm:w-auto';
+
+const CampusModeSelect = ({ value, onChange, className = selectClassName }) => (
+  <select
+    value={value}
+    onChange={onChange}
+    className={className}
+    aria-label="Filter by campus type"
+  >
+    {CAMPUS_MODE_FILTER_OPTIONS.map((option) => (
+      <option
+        key={option.value}
+        value={option.value}
+        style={{ backgroundColor: '#111827', color: 'white' }}
+      >
+        {option.label}
+      </option>
+    ))}
+  </select>
+);
+
+export default CampusModeSelect;

--- a/src/components/opportunities/OpportunityCard.jsx
+++ b/src/components/opportunities/OpportunityCard.jsx
@@ -11,6 +11,7 @@ import Card from '../common/Card';
 import Button from '../common/Button';
 import { getDaysRemaining, isOverdue, formatDate } from '../../utils/dateHelpers';
 import { getRoundSummaryLabel, getRoundSummaryStyle } from '../../utils/roundHelpers';
+import { getCampusModeLabel, CAMPUS_MODE_BADGE_STYLES } from '../../utils/opportunityHelpers';
 
 // Status badge color mappings
 const statusColors = {
@@ -39,6 +40,7 @@ const OpportunityCard = ({ opportunity, onView, onEdit, onDelete, onShare }) => 
   const daysRemaining = getDaysRemaining(opportunity.deadline);
   const overdue = isOverdue(opportunity.deadline);
   const roundSummary = getRoundSummaryLabel(opportunity);
+  const campusModeLabel = getCampusModeLabel(opportunity.campus_mode);
 
   const handleCardClick = () => {
     if (onView) {
@@ -126,6 +128,13 @@ const OpportunityCard = ({ opportunity, onView, onEdit, onDelete, onShare }) => 
               >
                 <FaLayerGroup size={10} aria-hidden="true" />
                 {roundSummary}
+              </span>
+            )}
+            {campusModeLabel && (
+              <span
+                className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${CAMPUS_MODE_BADGE_STYLES[opportunity.campus_mode]}`}
+              >
+                {campusModeLabel}
               </span>
             )}
           </div>

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -31,7 +31,7 @@ import Button from '../common/Button';
 import RoundTimeline, { RoundTimelineSkeleton } from '../rounds/RoundTimeline';
 import AddRoundModal from '../rounds/AddRoundModal';
 import { getDaysRemaining, isOverdue, formatDate } from '../../utils/dateHelpers';
-import { supportsDocuments } from '../../utils/opportunityHelpers';
+import { supportsDocuments, getCampusModeLabel, CAMPUS_MODE_BADGE_STYLES } from '../../utils/opportunityHelpers';
 import {
     getNextRoundNumber,
     getRoundProgressStats,
@@ -274,6 +274,11 @@ const OpportunityDetailModal = ({
                                     <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-purple-500/10 text-purple-300 border border-purple-500/20">
                                         <FaLayerGroup size={10} aria-hidden="true" />
                                         {roundStats.total} round{roundStats.total !== 1 ? 's' : ''}
+                                    </span>
+                                )}
+                                {getCampusModeLabel(displayOpportunity.campus_mode) && (
+                                    <span className={`px-3 py-1 rounded-full text-xs font-medium ${CAMPUS_MODE_BADGE_STYLES[displayOpportunity.campus_mode]}`}>
+                                        {getCampusModeLabel(displayOpportunity.campus_mode)}
                                     </span>
                                 )}
                             </div>

--- a/src/components/opportunities/OpportunityDetailModal.jsx
+++ b/src/components/opportunities/OpportunityDetailModal.jsx
@@ -191,6 +191,7 @@ const OpportunityDetailModal = ({
     const daysRemaining = getDaysRemaining(displayOpportunity.deadline);
     const overdue = isOverdue(displayOpportunity.deadline);
     const showInterviewRounds = supportsInterviewRounds(displayOpportunity.category);
+    const campusModeLabel = getCampusModeLabel(displayOpportunity.campus_mode);
 
     const handleOpenAddRound = () => {
         setEditingRound(null);
@@ -276,9 +277,9 @@ const OpportunityDetailModal = ({
                                         {roundStats.total} round{roundStats.total !== 1 ? 's' : ''}
                                     </span>
                                 )}
-                                {getCampusModeLabel(displayOpportunity.campus_mode) && (
+                                {campusModeLabel && (
                                     <span className={`px-3 py-1 rounded-full text-xs font-medium ${CAMPUS_MODE_BADGE_STYLES[displayOpportunity.campus_mode]}`}>
-                                        {getCampusModeLabel(displayOpportunity.campus_mode)}
+                                        {campusModeLabel}
                                     </span>
                                 )}
                             </div>

--- a/src/components/opportunities/OpportunityForm.jsx
+++ b/src/components/opportunities/OpportunityForm.jsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from 'react';
 import Button from '../common/Button';
 import DocumentSelector from '../documents/DocumentSelector';
-import { supportsDocuments } from '../../utils/opportunityHelpers';
+import { supportsDocuments, CAMPUS_MODE_FORM_OPTIONS } from '../../utils/opportunityHelpers';
 
 // initialData: values to pre-fill the form in edit mode
 // onSubmit: function passed from parent (Add / Edit page) to handle API call
@@ -20,6 +20,7 @@ const OpportunityForm = ({ initialData = {}, onSubmit, isEdit = false, opportuni
     category: 'internship',
     status: 'applied',
     notes: '',
+    campus_mode: '',
   });
 
   // Tracks validation error messages per field (e.g. errors.title)
@@ -36,6 +37,7 @@ const OpportunityForm = ({ initialData = {}, onSubmit, isEdit = false, opportuni
         category: initialData.category || 'internship',
         status: initialData.status || 'applied',
         notes: initialData.notes || '',
+        campus_mode: initialData.campus_mode || '',
       });
     }
   }, [initialData]);
@@ -84,7 +86,10 @@ const OpportunityForm = ({ initialData = {}, onSubmit, isEdit = false, opportuni
 
     // Only call parent onSubmit when validation passes
     if (validateForm()) {
-      onSubmit(formData);
+      onSubmit({
+        ...formData,
+        campus_mode: formData.campus_mode || null,
+      });
     }
   };
 
@@ -187,6 +192,30 @@ const OpportunityForm = ({ initialData = {}, onSubmit, isEdit = false, opportuni
           </label>
         </div>
         {errors.category && <p className="text-red-400 text-sm mt-1">{errors.category}</p>}
+      </div>
+
+      {/* Campus type (optional) */}
+      <div>
+        <label htmlFor="campus_mode" className="block text-sm font-medium text-gray-200 mb-1">
+          Campus type (optional)
+        </label>
+        <select
+          id="campus_mode"
+          name="campus_mode"
+          value={formData.campus_mode}
+          onChange={handleChange}
+          className="w-full px-3 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all"
+        >
+          {CAMPUS_MODE_FORM_OPTIONS.map((option) => (
+            <option
+              key={option.value || 'unset'}
+              value={option.value}
+              style={{ backgroundColor: '#111827', color: 'white' }}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
       </div>
 
       {/* Status */}

--- a/src/hooks/useCampusModeFilter.js
+++ b/src/hooks/useCampusModeFilter.js
@@ -10,8 +10,8 @@ export function useCampusModeFilter(initialFilter = DEFAULT_FILTER) {
   const [campusModeFilter, setCampusModeFilter] = useState(initialFilter);
 
   const resetCampusModeFilter = useCallback(() => {
-    setCampusModeFilter(DEFAULT_FILTER);
-  }, []);
+    setCampusModeFilter(initialFilter);
+  }, [initialFilter]);
 
   const applyCampusModeFilter = useCallback(
     (opportunities) => filterByCampusMode(opportunities, campusModeFilter),

--- a/src/hooks/useCampusModeFilter.js
+++ b/src/hooks/useCampusModeFilter.js
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react';
+import { filterByCampusMode } from '../utils/opportunityHelpers';
+
+const DEFAULT_FILTER = 'all';
+
+/**
+ * Shared campus-mode filter state for opportunity list pages.
+ */
+export function useCampusModeFilter(initialFilter = DEFAULT_FILTER) {
+  const [campusModeFilter, setCampusModeFilter] = useState(initialFilter);
+
+  const resetCampusModeFilter = useCallback(() => {
+    setCampusModeFilter(DEFAULT_FILTER);
+  }, []);
+
+  const applyCampusModeFilter = useCallback(
+    (opportunities) => filterByCampusMode(opportunities, campusModeFilter),
+    [campusModeFilter]
+  );
+
+  return {
+    campusModeFilter,
+    setCampusModeFilter,
+    resetCampusModeFilter,
+    isCampusFilterActive: campusModeFilter !== DEFAULT_FILTER,
+    applyCampusModeFilter,
+  };
+}

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -44,6 +44,11 @@ const Analytics = () => {
 
     const PIE_COLORS = ['#3B82F6', '#F59E0B', '#8B5CF6', '#10B981', '#EF4444', '#94A3B8'];
     const CATEGORY_COLORS = { internship: '#6366F1', hackathon: '#EC4899' };
+    const CAMPUS_MODE_COLORS = {
+        on_campus: '#14B8A6',
+        off_campus: '#F97316',
+        unspecified: '#6B7280',
+    };
 
     // Transform status data for pie chart
     const getStatusPieData = () => {
@@ -279,8 +284,8 @@ const Analytics = () => {
                     </Card>
                 </div>
 
-                {/* Conversion Funnel & Category Breakdown */}
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+                {/* Conversion Funnel, Category & Campus Mode */}
+                <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mb-8">
                     {/* Conversion Funnel */}
                     <Card className="p-6">
                         <h3 className="text-lg font-semibold text-white mb-4">Conversion Funnel</h3>
@@ -354,6 +359,71 @@ const Analytics = () => {
                                 <span className="text-gray-300 text-sm">Hackathons</span>
                             </div>
                         </div>
+                    </Card>
+
+                    {/* Campus Mode Breakdown */}
+                    <Card className="p-6">
+                        <h3 className="text-lg font-semibold text-white mb-4">Campus Mode Breakdown</h3>
+                        {analytics.campusModeCounts ? (
+                            <>
+                                <div className="h-64">
+                                    <ResponsiveContainer width="100%" height="100%">
+                                        <BarChart
+                                            data={[
+                                                { name: 'On-campus', value: analytics.campusModeCounts.on_campus, fill: CAMPUS_MODE_COLORS.on_campus },
+                                                { name: 'Off-campus', value: analytics.campusModeCounts.off_campus, fill: CAMPUS_MODE_COLORS.off_campus },
+                                                { name: 'Not specified', value: analytics.campusModeCounts.unspecified, fill: CAMPUS_MODE_COLORS.unspecified },
+                                            ]}
+                                            layout="vertical"
+                                        >
+                                            <CartesianGrid strokeDasharray="3 3" stroke="#374151" horizontal={false} />
+                                            <XAxis type="number" stroke="#9CA3AF" tick={{ fill: '#9CA3AF' }} allowDecimals={false} />
+                                            <YAxis type="category" dataKey="name" stroke="#9CA3AF" tick={{ fill: '#9CA3AF' }} width={100} />
+                                            <Tooltip
+                                                content={({ active, payload }) => {
+                                                    if (active && payload && payload.length) {
+                                                        return (
+                                                            <div className="bg-gray-900/95 backdrop-blur-sm px-4 py-2 rounded-lg border border-white/10">
+                                                                <p className="text-white font-medium">{payload[0].payload.name}</p>
+                                                                <p className="text-gray-300">{payload[0].value} opportunities</p>
+                                                            </div>
+                                                        );
+                                                    }
+                                                    return null;
+                                                }}
+                                            />
+                                            <Bar dataKey="value" radius={[0, 8, 8, 0]} animationDuration={800}>
+                                                {[
+                                                    { fill: CAMPUS_MODE_COLORS.on_campus },
+                                                    { fill: CAMPUS_MODE_COLORS.off_campus },
+                                                    { fill: CAMPUS_MODE_COLORS.unspecified },
+                                                ].map((entry, index) => (
+                                                    <Cell key={`campus-cell-${index}`} fill={entry.fill} />
+                                                ))}
+                                            </Bar>
+                                        </BarChart>
+                                    </ResponsiveContainer>
+                                </div>
+                                <div className="mt-4 flex flex-wrap justify-center gap-6">
+                                    <div className="flex items-center gap-2">
+                                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: CAMPUS_MODE_COLORS.on_campus }}></div>
+                                        <span className="text-gray-300 text-sm">On-campus</span>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: CAMPUS_MODE_COLORS.off_campus }}></div>
+                                        <span className="text-gray-300 text-sm">Off-campus</span>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: CAMPUS_MODE_COLORS.unspecified }}></div>
+                                        <span className="text-gray-300 text-sm">Not specified</span>
+                                    </div>
+                                </div>
+                            </>
+                        ) : (
+                            <div className="h-64 flex items-center justify-center text-gray-400">
+                                No campus data to display
+                            </div>
+                        )}
                     </Card>
                 </div>
 

--- a/src/pages/HackathonList.jsx
+++ b/src/pages/HackathonList.jsx
@@ -16,8 +16,9 @@ import OpportunityList from '../components/opportunities/OpportunityList';
 import OpportunityDetailModal from '../components/opportunities/OpportunityDetailModal';
 import Modal from '../components/common/Modal';
 import Button from '../components/common/Button';
+import CampusModeSelect from '../components/opportunities/CampusModeSelect';
 import { opportunityService } from '../services/api';
-import { CAMPUS_MODE_FILTER_OPTIONS } from '../utils/opportunityHelpers';
+import { useCampusModeFilter } from '../hooks/useCampusModeFilter';
 
 const HackathonList = () => {
   const navigate = useNavigate();
@@ -25,7 +26,13 @@ const HackathonList = () => {
   const [filteredOpportunities, setFilteredOpportunities] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
-  const [campusModeFilter, setCampusModeFilter] = useState('all');
+  const {
+    campusModeFilter,
+    setCampusModeFilter,
+    resetCampusModeFilter,
+    isCampusFilterActive,
+    applyCampusModeFilter,
+  } = useCampusModeFilter();
   const [loading, setLoading] = useState(true);
 
   // Modal states
@@ -42,7 +49,7 @@ const HackathonList = () => {
   useEffect(() => {
     applyFilters();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, statusFilter, campusModeFilter, opportunities]);
+  }, [searchQuery, statusFilter, campusModeFilter, opportunities, applyCampusModeFilter]);
 
   /**
    * Fetch all opportunities and filter for hackathons only
@@ -81,7 +88,7 @@ const HackathonList = () => {
     }
 
     if (campusModeFilter !== 'all') {
-      filtered = filtered.filter((opp) => opp.campus_mode === campusModeFilter);
+      filtered = applyCampusModeFilter(filtered);
     }
 
     setFilteredOpportunities(filtered);
@@ -138,7 +145,7 @@ const HackathonList = () => {
   const clearFilters = () => {
     setSearchQuery('');
     setStatusFilter('all');
-    setCampusModeFilter('all');
+    resetCampusModeFilter();
   };
 
   return (
@@ -199,23 +206,12 @@ const HackathonList = () => {
                 <option value="ghosted" style={{ backgroundColor: '#111827', color: 'white' }}>Ghosted</option>
               </select>
 
-              <select
+              <CampusModeSelect
                 value={campusModeFilter}
                 onChange={(e) => setCampusModeFilter(e.target.value)}
-                className="px-4 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all w-full sm:w-auto"
-              >
-                {CAMPUS_MODE_FILTER_OPTIONS.map((option) => (
-                  <option
-                    key={option.value}
-                    value={option.value}
-                    style={{ backgroundColor: '#111827', color: 'white' }}
-                  >
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+              />
 
-              {(searchQuery || statusFilter !== 'all' || campusModeFilter !== 'all') && (
+              {(searchQuery || statusFilter !== 'all' || isCampusFilterActive) && (
                 <Button variant="secondary" onClick={clearFilters} className="w-full sm:w-auto">
                   Clear
                 </Button>

--- a/src/pages/HackathonList.jsx
+++ b/src/pages/HackathonList.jsx
@@ -17,6 +17,7 @@ import OpportunityDetailModal from '../components/opportunities/OpportunityDetai
 import Modal from '../components/common/Modal';
 import Button from '../components/common/Button';
 import { opportunityService } from '../services/api';
+import { CAMPUS_MODE_FILTER_OPTIONS } from '../utils/opportunityHelpers';
 
 const HackathonList = () => {
   const navigate = useNavigate();
@@ -24,6 +25,7 @@ const HackathonList = () => {
   const [filteredOpportunities, setFilteredOpportunities] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
+  const [campusModeFilter, setCampusModeFilter] = useState('all');
   const [loading, setLoading] = useState(true);
 
   // Modal states
@@ -40,7 +42,7 @@ const HackathonList = () => {
   useEffect(() => {
     applyFilters();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, statusFilter, opportunities]);
+  }, [searchQuery, statusFilter, campusModeFilter, opportunities]);
 
   /**
    * Fetch all opportunities and filter for hackathons only
@@ -76,6 +78,10 @@ const HackathonList = () => {
 
     if (statusFilter !== 'all') {
       filtered = filtered.filter(opp => opp.status === statusFilter);
+    }
+
+    if (campusModeFilter !== 'all') {
+      filtered = filtered.filter((opp) => opp.campus_mode === campusModeFilter);
     }
 
     setFilteredOpportunities(filtered);
@@ -132,6 +138,7 @@ const HackathonList = () => {
   const clearFilters = () => {
     setSearchQuery('');
     setStatusFilter('all');
+    setCampusModeFilter('all');
   };
 
   return (
@@ -192,7 +199,23 @@ const HackathonList = () => {
                 <option value="ghosted" style={{ backgroundColor: '#111827', color: 'white' }}>Ghosted</option>
               </select>
 
-              {(searchQuery || statusFilter !== 'all') && (
+              <select
+                value={campusModeFilter}
+                onChange={(e) => setCampusModeFilter(e.target.value)}
+                className="px-4 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all w-full sm:w-auto"
+              >
+                {CAMPUS_MODE_FILTER_OPTIONS.map((option) => (
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    style={{ backgroundColor: '#111827', color: 'white' }}
+                  >
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+
+              {(searchQuery || statusFilter !== 'all' || campusModeFilter !== 'all') && (
                 <Button variant="secondary" onClick={clearFilters} className="w-full sm:w-auto">
                   Clear
                 </Button>

--- a/src/pages/InternshipList.jsx
+++ b/src/pages/InternshipList.jsx
@@ -18,7 +18,7 @@ import Modal from '../components/common/Modal';
 import Button from '../components/common/Button';
 import ShareProgressModal from '../components/sharing/ShareProgressModal';
 import { opportunityService } from '../services/api';
-import { isActiveInternshipStatus } from '../utils/opportunityHelpers';
+import { isActiveInternshipStatus, CAMPUS_MODE_FILTER_OPTIONS } from '../utils/opportunityHelpers';
 
 const InternshipList = () => {
   const navigate = useNavigate();
@@ -26,6 +26,7 @@ const InternshipList = () => {
   const [filteredOpportunities, setFilteredOpportunities] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('active');
+  const [campusModeFilter, setCampusModeFilter] = useState('all');
   const [loading, setLoading] = useState(true);
 
   // Modal states
@@ -44,7 +45,7 @@ const InternshipList = () => {
   useEffect(() => {
     applyFilters();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, statusFilter, opportunities]);
+  }, [searchQuery, statusFilter, campusModeFilter, opportunities]);
 
   /**
    * Fetch all opportunities and filter for internships only
@@ -82,6 +83,10 @@ const InternshipList = () => {
       filtered = filtered.filter((opp) => isActiveInternshipStatus(opp.status));
     } else if (statusFilter !== 'all') {
       filtered = filtered.filter(opp => opp.status === statusFilter);
+    }
+
+    if (campusModeFilter !== 'all') {
+      filtered = filtered.filter((opp) => opp.campus_mode === campusModeFilter);
     }
 
     setFilteredOpportunities(filtered);
@@ -165,6 +170,7 @@ const InternshipList = () => {
   const clearFilters = () => {
     setSearchQuery('');
     setStatusFilter('active');
+    setCampusModeFilter('all');
   };
 
   return (
@@ -226,7 +232,23 @@ const InternshipList = () => {
                 <option value="ghosted" style={{ backgroundColor: '#111827', color: 'white' }}>Ghosted</option>
               </select>
 
-              {(searchQuery || statusFilter !== 'active') && (
+              <select
+                value={campusModeFilter}
+                onChange={(e) => setCampusModeFilter(e.target.value)}
+                className="px-4 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all w-full sm:w-auto"
+              >
+                {CAMPUS_MODE_FILTER_OPTIONS.map((option) => (
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    style={{ backgroundColor: '#111827', color: 'white' }}
+                  >
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+
+              {(searchQuery || statusFilter !== 'active' || campusModeFilter !== 'all') && (
                 <Button variant="secondary" onClick={clearFilters} className="w-full sm:w-auto">
                   Clear
                 </Button>

--- a/src/pages/InternshipList.jsx
+++ b/src/pages/InternshipList.jsx
@@ -17,8 +17,10 @@ import OpportunityDetailModal from '../components/opportunities/OpportunityDetai
 import Modal from '../components/common/Modal';
 import Button from '../components/common/Button';
 import ShareProgressModal from '../components/sharing/ShareProgressModal';
+import CampusModeSelect from '../components/opportunities/CampusModeSelect';
 import { opportunityService } from '../services/api';
-import { isActiveInternshipStatus, CAMPUS_MODE_FILTER_OPTIONS } from '../utils/opportunityHelpers';
+import { isActiveInternshipStatus } from '../utils/opportunityHelpers';
+import { useCampusModeFilter } from '../hooks/useCampusModeFilter';
 
 const InternshipList = () => {
   const navigate = useNavigate();
@@ -26,7 +28,13 @@ const InternshipList = () => {
   const [filteredOpportunities, setFilteredOpportunities] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('active');
-  const [campusModeFilter, setCampusModeFilter] = useState('all');
+  const {
+    campusModeFilter,
+    setCampusModeFilter,
+    resetCampusModeFilter,
+    isCampusFilterActive,
+    applyCampusModeFilter,
+  } = useCampusModeFilter();
   const [loading, setLoading] = useState(true);
 
   // Modal states
@@ -45,7 +53,7 @@ const InternshipList = () => {
   useEffect(() => {
     applyFilters();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, statusFilter, campusModeFilter, opportunities]);
+  }, [searchQuery, statusFilter, campusModeFilter, opportunities, applyCampusModeFilter]);
 
   /**
    * Fetch all opportunities and filter for internships only
@@ -85,9 +93,7 @@ const InternshipList = () => {
       filtered = filtered.filter(opp => opp.status === statusFilter);
     }
 
-    if (campusModeFilter !== 'all') {
-      filtered = filtered.filter((opp) => opp.campus_mode === campusModeFilter);
-    }
+    filtered = applyCampusModeFilter(filtered);
 
     setFilteredOpportunities(filtered);
   };
@@ -170,7 +176,7 @@ const InternshipList = () => {
   const clearFilters = () => {
     setSearchQuery('');
     setStatusFilter('active');
-    setCampusModeFilter('all');
+    resetCampusModeFilter();
   };
 
   return (
@@ -232,23 +238,12 @@ const InternshipList = () => {
                 <option value="ghosted" style={{ backgroundColor: '#111827', color: 'white' }}>Ghosted</option>
               </select>
 
-              <select
+              <CampusModeSelect
                 value={campusModeFilter}
                 onChange={(e) => setCampusModeFilter(e.target.value)}
-                className="px-4 py-2.5 bg-gray-900 border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all w-full sm:w-auto"
-              >
-                {CAMPUS_MODE_FILTER_OPTIONS.map((option) => (
-                  <option
-                    key={option.value}
-                    value={option.value}
-                    style={{ backgroundColor: '#111827', color: 'white' }}
-                  >
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+              />
 
-              {(searchQuery || statusFilter !== 'active' || campusModeFilter !== 'all') && (
+              {(searchQuery || statusFilter !== 'active' || isCampusFilterActive) && (
                 <Button variant="secondary" onClick={clearFilters} className="w-full sm:w-auto">
                   Clear
                 </Button>

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -12,7 +12,6 @@ import SEO from '../components/seo/SEO';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import InterviewRejectionInsights from '../components/analytics/InterviewRejectionInsights';
-import InterviewFunnelChart from '../components/analytics/InterviewFunnelChart';
 import StatusIndicator from '../components/common/StatusIndicator';
 import { opportunityService, analyticsService } from '../services/api';
 import { generatePDF, downloadPDF } from '../utils/pdfExport';
@@ -491,9 +490,6 @@ const Reports = () => {
             showMetrics={false}
             showCharts={showPipelineSection}
           />
-          {showPipelineSection && (
-            <InterviewFunnelChart pipeline={displayPipeline} compact />
-          )}
         </section>
 
         <div className="flex justify-end pt-2">

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -12,11 +12,17 @@ import SEO from '../components/seo/SEO';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import InterviewRejectionInsights from '../components/analytics/InterviewRejectionInsights';
+import InterviewFunnelChart from '../components/analytics/InterviewFunnelChart';
 import StatusIndicator from '../components/common/StatusIndicator';
 import { opportunityService, analyticsService } from '../services/api';
 import { generatePDF, downloadPDF } from '../utils/pdfExport';
 import { formatDate } from '../utils/dateHelpers';
 import { getRejectionStageForOpportunity, filterPipelineAnalyticsForOpportunities } from '../utils/roundHelpers';
+import {
+  calculateCampusModeStats,
+  getCampusModeLabel,
+  CAMPUS_MODE_BADGE_STYLES,
+} from '../utils/opportunityHelpers';
 
 const STATUS_STYLES = {
   applied: 'bg-blue-500/15 text-blue-300 border-blue-500/25',
@@ -100,6 +106,13 @@ const Reports = () => {
     [exportType, previewOpportunities, opportunities]
   );
 
+  const campusModeStats = useMemo(
+    () => calculateCampusModeStats(
+      exportType === 'selected' ? previewOpportunities : opportunities
+    ),
+    [exportType, previewOpportunities, opportunities]
+  );
+
   const displayPipeline = useMemo(() => {
     if (!pipelineAnalytics) return null;
     if (exportType === 'selected' && previewOpportunities.length > 0) {
@@ -143,7 +156,8 @@ const Reports = () => {
           ? filterPipelineAnalyticsForOpportunities(pipelineAnalytics, oppsToExport)
           : pipelineAnalytics;
 
-      const doc = generatePDF(oppsToExport, stats, exportType, pipelineForExport);
+      const statsScope = exportType === 'selected' ? oppsToExport : opportunities;
+      const doc = generatePDF(oppsToExport, stats, exportType, pipelineForExport, statsScope);
       downloadPDF(doc, `futurestack-report-${new Date().toISOString().split('T')[0]}.pdf`);
       toast.success('PDF report generated successfully!');
     } catch (error) {
@@ -347,6 +361,23 @@ const Reports = () => {
                       </div>
                     ))}
                 </div>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  {[
+                    { key: 'on_campus', label: 'On-campus' },
+                    { key: 'off_campus', label: 'Off-campus' },
+                    { key: 'unspecified', label: 'Not specified' },
+                  ].map(({ key, label }) => (
+                    <div
+                      key={key}
+                      className="rounded-lg border border-white/10 bg-white/5 px-3 py-2"
+                    >
+                      <p className="text-xs text-gray-500">{label}</p>
+                      <p className="text-lg font-semibold text-white tabular-nums">
+                        {campusModeStats[key]}
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
             ) : previewOpportunities.length === 0 ? (
               <p className="text-gray-400 text-center py-16">No opportunities to preview</p>
@@ -360,6 +391,7 @@ const Reports = () => {
                   );
                   const statusClass =
                     STATUS_STYLES[opp.status] || 'bg-gray-500/15 text-gray-300 border-gray-500/25';
+                  const campusLabel = getCampusModeLabel(opp.campus_mode);
 
                   return (
                     <div
@@ -384,11 +416,20 @@ const Reports = () => {
                         <div className="flex-1 min-w-0">
                           <div className="flex flex-wrap items-start justify-between gap-2 mb-2">
                             <h3 className="font-semibold text-white leading-snug">{opp.title}</h3>
-                            <span
-                              className={`text-xs font-medium px-2 py-0.5 rounded-full border shrink-0 capitalize ${statusClass}`}
-                            >
-                              {opp.status}
-                            </span>
+                            <div className="flex flex-wrap items-center gap-2 shrink-0">
+                              {campusLabel && (
+                                <span
+                                  className={`text-xs font-medium px-2 py-0.5 rounded-full border ${CAMPUS_MODE_BADGE_STYLES[opp.campus_mode]}`}
+                                >
+                                  {campusLabel}
+                                </span>
+                              )}
+                              <span
+                                className={`text-xs font-medium px-2 py-0.5 rounded-full border capitalize ${statusClass}`}
+                              >
+                                {opp.status}
+                              </span>
+                            </div>
                           </div>
 
                           <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400 mb-2">
@@ -450,6 +491,9 @@ const Reports = () => {
             showMetrics={false}
             showCharts={showPipelineSection}
           />
+          {showPipelineSection && (
+            <InterviewFunnelChart pipeline={displayPipeline} compact />
+          )}
         </section>
 
         <div className="flex justify-end pt-2">

--- a/src/utils/opportunityHelpers.js
+++ b/src/utils/opportunityHelpers.js
@@ -37,3 +37,46 @@ export const getDocumentUnavailableMessage = (category) => {
     }
     return 'Document attachments are only available for internship opportunities.';
 };
+
+/** Human-readable labels for campus_mode values. */
+export const getCampusModeLabel = (mode) => {
+    if (mode === 'on_campus') return 'On-campus';
+    if (mode === 'off_campus') return 'Off-campus';
+    return null;
+};
+
+export const CAMPUS_MODE_BADGE_STYLES = {
+    on_campus: 'bg-teal-500/10 text-teal-400 border border-teal-500/20',
+    off_campus: 'bg-orange-500/10 text-orange-400 border border-orange-500/20',
+};
+
+export const CAMPUS_MODE_FILTER_OPTIONS = [
+    { value: 'all', label: 'All campus types' },
+    { value: 'on_campus', label: 'On-campus' },
+    { value: 'off_campus', label: 'Off-campus' },
+];
+
+export const CAMPUS_MODE_FORM_OPTIONS = [
+    { value: '', label: 'Not specified' },
+    { value: 'on_campus', label: 'On-campus' },
+    { value: 'off_campus', label: 'Off-campus' },
+];
+
+/**
+ * Count campus_mode values for a list of opportunities.
+ * @param {Array} opportunities
+ * @returns {{ on_campus: number, off_campus: number, unspecified: number }}
+ */
+export const calculateCampusModeStats = (opportunities = []) => {
+    const stats = { on_campus: 0, off_campus: 0, unspecified: 0 };
+    opportunities.forEach((opp) => {
+        if (opp.campus_mode === 'on_campus') {
+            stats.on_campus++;
+        } else if (opp.campus_mode === 'off_campus') {
+            stats.off_campus++;
+        } else {
+            stats.unspecified++;
+        }
+    });
+    return stats;
+};

--- a/src/utils/opportunityHelpers.js
+++ b/src/utils/opportunityHelpers.js
@@ -80,3 +80,11 @@ export const calculateCampusModeStats = (opportunities = []) => {
     });
     return stats;
 };
+
+/** Filter opportunities by campus_mode when filter is not 'all'. */
+export const filterByCampusMode = (opportunities, campusModeFilter) => {
+    if (campusModeFilter === 'all') {
+        return opportunities;
+    }
+    return opportunities.filter((opp) => opp.campus_mode === campusModeFilter);
+};

--- a/src/utils/opportunityHelpers.test.js
+++ b/src/utils/opportunityHelpers.test.js
@@ -4,6 +4,8 @@ import {
     getDocumentUnavailableMessage,
     isActiveInternshipStatus,
     INACTIVE_INTERNSHIP_STATUSES,
+    getCampusModeLabel,
+    calculateCampusModeStats,
 } from './opportunityHelpers';
 
 describe('opportunityHelpers', () => {
@@ -43,6 +45,34 @@ describe('opportunityHelpers', () => {
         it('treats rejected, selected, and ghosted as inactive', () => {
             INACTIVE_INTERNSHIP_STATUSES.forEach((status) => {
                 expect(isActiveInternshipStatus(status)).toBe(false);
+            });
+        });
+    });
+
+    describe('getCampusModeLabel', () => {
+        it('returns labels for known campus modes', () => {
+            expect(getCampusModeLabel('on_campus')).toBe('On-campus');
+            expect(getCampusModeLabel('off_campus')).toBe('Off-campus');
+        });
+
+        it('returns null for unset campus mode', () => {
+            expect(getCampusModeLabel(null)).toBeNull();
+            expect(getCampusModeLabel(undefined)).toBeNull();
+        });
+    });
+
+    describe('calculateCampusModeStats', () => {
+        it('counts campus modes in a list', () => {
+            expect(
+                calculateCampusModeStats([
+                    { campus_mode: 'on_campus' },
+                    { campus_mode: 'off_campus' },
+                    { campus_mode: null },
+                ])
+            ).toEqual({
+                on_campus: 1,
+                off_campus: 1,
+                unspecified: 1,
             });
         });
     });

--- a/src/utils/opportunityHelpers.test.js
+++ b/src/utils/opportunityHelpers.test.js
@@ -6,6 +6,7 @@ import {
     INACTIVE_INTERNSHIP_STATUSES,
     getCampusModeLabel,
     calculateCampusModeStats,
+    filterByCampusMode,
 } from './opportunityHelpers';
 
 describe('opportunityHelpers', () => {
@@ -74,6 +75,27 @@ describe('opportunityHelpers', () => {
                 off_campus: 1,
                 unspecified: 1,
             });
+        });
+    });
+
+    describe('filterByCampusMode', () => {
+        const opportunities = [
+            { campus_mode: 'on_campus' },
+            { campus_mode: 'off_campus' },
+            { campus_mode: null },
+        ];
+
+        it('returns all opportunities when filter is all', () => {
+            expect(filterByCampusMode(opportunities, 'all')).toHaveLength(3);
+        });
+
+        it('filters by on_campus or off_campus', () => {
+            expect(filterByCampusMode(opportunities, 'on_campus')).toEqual([
+                { campus_mode: 'on_campus' },
+            ]);
+            expect(filterByCampusMode(opportunities, 'off_campus')).toEqual([
+                { campus_mode: 'off_campus' },
+            ]);
         });
     });
 });

--- a/src/utils/pdfExport.js
+++ b/src/utils/pdfExport.js
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import { formatDate } from './dateHelpers';
+import { getCampusModeLabel, calculateCampusModeStats } from './opportunityHelpers';
 
 /**
  * Generate PDF report from opportunities data
@@ -7,8 +8,15 @@ import { formatDate } from './dateHelpers';
  * @param {Object} statistics - Statistics object with counts
  * @param {string} exportType - Type of export: 'all', 'selected', or 'summary'
  * @param {Object|null} pipelineAnalytics - Interview pipeline rejection analytics
+ * @param {Array} [statsOpportunities] - Opportunities used for campus mode summary counts
  */
-export const generatePDF = (opportunities, statistics, exportType = 'all', pipelineAnalytics = null) => {
+export const generatePDF = (
+  opportunities,
+  statistics,
+  exportType = 'all',
+  pipelineAnalytics = null,
+  statsOpportunities = opportunities
+) => {
   const doc = new jsPDF();
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
@@ -74,6 +82,27 @@ export const generatePDF = (opportunities, statistics, exportType = 'all', pipel
     doc.text(stat, margin + 5, yPosition);
     yPosition += 6;
   });
+
+  const campusStats = calculateCampusModeStats(statsOpportunities);
+  if (campusStats.on_campus > 0 || campusStats.off_campus > 0 || campusStats.unspecified > 0) {
+    yPosition += 4;
+    doc.setFontSize(12);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Campus Mode', margin, yPosition);
+    yPosition += 7;
+
+    doc.setFontSize(11);
+    doc.setFont('helvetica', 'normal');
+    const campusLines = [
+      `On-campus: ${campusStats.on_campus}`,
+      `Off-campus: ${campusStats.off_campus}`,
+      `Not specified: ${campusStats.unspecified}`,
+    ];
+    campusLines.forEach((line) => {
+      doc.text(line, margin + 5, yPosition);
+      yPosition += 6;
+    });
+  }
 
   yPosition += 10;
 
@@ -161,6 +190,11 @@ export const generatePDF = (opportunities, statistics, exportType = 'all', pipel
       `Status: ${opp.status.charAt(0).toUpperCase() + opp.status.slice(1)}`,
       `Deadline: ${formatDate(opp.deadline)}`,
     ];
+
+    const campusLabel = getCampusModeLabel(opp.campus_mode);
+    if (campusLabel) {
+      details.push(`Campus type: ${campusLabel}`);
+    }
 
     if (opp.status === 'rejected') {
       const rejection = rejectionByOpportunityId.get(opp.id);


### PR DESCRIPTION
## Summary

- Adds optional `campus_mode` field (`on_campus` / `off_campus` / `NULL`) to opportunities for tracking campus drives vs off-campus applications
- Includes DB migration, API validation, form control, card/modal badges, list filtering, analytics breakdown, and PDF export support

Closes #57

## Test plan

- [x] `cd backend && npm test`
- [x] `npm run test:ci`
- [x] `npm run build`
- [ ] Run `docs/opportunity-campus-mode-migration.sql` in Supabase SQL Editor before deploying
- [ ] Create opportunity with **On-campus** → badge appears on card and detail modal
- [ ] Edit to **Off-campus** → badge updates; clear to **Not specified** → badge disappears
- [ ] Filter Internship / Hackathon lists by campus mode
- [ ] Verify Analytics campus breakdown chart and Reports PDF campus summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional campus type (on-campus, off-campus, or not specified) to opportunity create/edit, displayed on opportunity cards and the detail modal.
  * Added campus mode breakdown to Analytics and campus mode stats to Reports (preview + PDF summary).
  * Added campus type filtering to internship and hackathon listings.
* **Bug Fixes**
  * Improved handling of clearing campus type (empty/null) with consistent validation and persistence.
* **Documentation**
  * Added database migration/schema updates for the new `campus_mode` field.
* **Tests**
  * Added integration/unit test coverage for campus mode validation, persistence, filtering, and Analytics output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->