### PR TITLE
feat: interview rounds epic follow-ups

### DIFF
--- a/backend/src/lib/interviewPipelineAnalytics.js
+++ b/backend/src/lib/interviewPipelineAnalytics.js
@@ -35,6 +35,70 @@ function formatRejectionStage(roundNumber, roundType) {
     return 'Stage not recorded';
 }
 
+function buildFunnelByRoundType(internships, roundsByOpportunity) {
+    const statsByType = {};
+
+    for (const opp of internships) {
+        const oppRounds = (roundsByOpportunity[opp.id] || []).slice().sort(
+            (a, b) => a.round_number - b.round_number
+        );
+
+        for (const round of oppRounds) {
+            const roundType = round.round_type;
+            if (!statsByType[roundType]) {
+                statsByType[roundType] = { reached: 0, cleared: 0, rejected: 0 };
+            }
+            statsByType[roundType].reached += 1;
+
+            if (round.result === 'cleared') {
+                statsByType[roundType].cleared += 1;
+            } else if (round.result === 'rejected') {
+                statsByType[roundType].rejected += 1;
+            }
+        }
+    }
+
+    return Object.entries(statsByType)
+        .map(([roundType, counts]) => ({
+            roundType,
+            label: getRoundTypeLabel(roundType),
+            reached: counts.reached,
+            cleared: counts.cleared,
+            rejected: counts.rejected,
+            clearanceRate:
+                counts.reached > 0
+                    ? roundToOneDecimal((counts.cleared / counts.reached) * 100)
+                    : null,
+        }))
+        .sort((a, b) => b.reached - a.reached);
+}
+
+function buildStageReachByRoundNumber(internships, roundsByOpportunity) {
+    const statsByNumber = {};
+
+    for (const opp of internships) {
+        const oppRounds = roundsByOpportunity[opp.id] || [];
+        for (const round of oppRounds) {
+            const roundNumber = round.round_number;
+            if (!statsByNumber[roundNumber]) {
+                statsByNumber[roundNumber] = { reached: 0, stillActive: 0 };
+            }
+            statsByNumber[roundNumber].reached += 1;
+            if (round.result === 'pending') {
+                statsByNumber[roundNumber].stillActive += 1;
+            }
+        }
+    }
+
+    return Object.entries(statsByNumber)
+        .map(([roundNumber, counts]) => ({
+            roundNumber: Number(roundNumber),
+            reached: counts.reached,
+            stillActive: counts.stillActive,
+        }))
+        .sort((a, b) => a.roundNumber - b.roundNumber);
+}
+
 /**
  * Build internship interview-pipeline analytics for dashboards and reports.
  */
@@ -111,12 +175,16 @@ function buildInterviewPipelineAnalytics(opportunities, rounds = []) {
                 count
             }))
             .sort((a, b) => b.count - a.count),
+        funnelByRoundType: buildFunnelByRoundType(internships, roundsByOpportunity),
+        stageReachByRoundNumber: buildStageReachByRoundNumber(internships, roundsByOpportunity),
         rejections
     };
 }
 
 module.exports = {
     buildInterviewPipelineAnalytics,
+    buildFunnelByRoundType,
+    buildStageReachByRoundNumber,
     groupRoundsByOpportunity,
     findRejectedRoundRecord,
     formatRejectionStage

--- a/backend/src/lib/interviewPipelineAnalytics.js
+++ b/backend/src/lib/interviewPipelineAnalytics.js
@@ -39,9 +39,7 @@ function buildFunnelByRoundType(internships, roundsByOpportunity) {
     const statsByType = {};
 
     for (const opp of internships) {
-        const oppRounds = (roundsByOpportunity[opp.id] || []).slice().sort(
-            (a, b) => a.round_number - b.round_number
-        );
+        const oppRounds = roundsByOpportunity[opp.id] || [];
 
         for (const round of oppRounds) {
             const roundType = round.round_type;

--- a/backend/src/lib/shareLinks.js
+++ b/backend/src/lib/shareLinks.js
@@ -142,7 +142,7 @@ function normalizeFieldOptions(fields = {}) {
     };
 }
 
-function toPublicOpportunity(opportunity, fields) {
+function toPublicOpportunity(opportunity, fields, interviewRounds = null) {
     const item = {
         id: opportunity.id,
         title: opportunity.title,
@@ -177,13 +177,26 @@ function toPublicOpportunity(opportunity, fields) {
         item.dateApplied = opportunity.created_at || null;
     }
 
+    if (fields.rounds && interviewRounds?.length) {
+        item.interviewRounds = interviewRounds.map((round) => ({
+            roundNumber: round.round_number,
+            roundType: round.round_type,
+            scheduledDate: round.scheduled_date || null,
+            result: round.result,
+        }));
+    }
+
     return item;
 }
 
-function buildShareSnapshot({ opportunities, fields, expiry, selectedOpportunityIds }) {
+function buildShareSnapshot({ opportunities, fields, expiry, selectedOpportunityIds, roundsByOpportunity = {} }) {
     const normalizedFields = normalizeFieldOptions(fields);
     const publicOpportunities = opportunities.map((opportunity) =>
-        toPublicOpportunity(opportunity, normalizedFields)
+        toPublicOpportunity(
+            opportunity,
+            normalizedFields,
+            roundsByOpportunity[opportunity.id] || null
+        )
     );
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -214,8 +227,12 @@ function buildShareSnapshot({ opportunities, fields, expiry, selectedOpportunity
         return deadline < today;
     }).length;
 
+    const hasInterviewTimelines = publicOpportunities.some(
+        (opportunity) => opportunity.interviewRounds?.length > 0
+    );
+
     return {
-        version: 2,
+        version: hasInterviewTimelines ? 3 : 2,
         generatedAt: new Date().toISOString(),
         shareType: 'placement_dashboard',
         options: {

--- a/backend/src/routes/opportunities.js
+++ b/backend/src/routes/opportunities.js
@@ -3,6 +3,7 @@ const { supabase } = require('../lib/supabase');
 const { validate } = require('../middleware/validate');
 const { createOpportunitySchema, updateOpportunitySchema, idParamSchema } = require('../validation/schemas');
 const opportunityRoundsRouter = require('./opportunity-rounds');
+const upcomingRoundsRouter = require('./upcoming-rounds');
 
 const router = express.Router();
 
@@ -72,7 +73,10 @@ router.get('/', async (req, res) => {
     }
 });
 
-// Interview rounds (must be registered before /:id to avoid route shadowing)
+// Upcoming rounds across all internships (before /:opportunityId/rounds)
+router.use('/rounds', upcomingRoundsRouter);
+
+// Interview rounds per opportunity (must be registered before /:id to avoid route shadowing)
 router.use('/:opportunityId/rounds', opportunityRoundsRouter);
 
 /**

--- a/backend/src/routes/share-links.js
+++ b/backend/src/routes/share-links.js
@@ -92,6 +92,30 @@ router.post('/', validate(createShareLinkSchema), async (req, res) => {
         const { data: opportunities, error: opportunitiesError } = await query;
         if (opportunitiesError) throw opportunitiesError;
 
+        const opportunityList = opportunities || [];
+        const internshipIds = opportunityList
+            .filter((opp) => opp.category === 'internship')
+            .map((opp) => opp.id);
+
+        let roundsByOpportunity = {};
+        if (internshipIds.length > 0 && fields?.rounds !== false) {
+            const { data: rounds, error: roundsError } = await supabase
+                .from('opportunity_rounds')
+                .select('opportunity_id, round_number, round_type, scheduled_date, result')
+                .eq('user_id', userId)
+                .in('opportunity_id', internshipIds)
+                .order('round_number', { ascending: true });
+
+            if (roundsError) throw roundsError;
+
+            for (const round of rounds || []) {
+                if (!roundsByOpportunity[round.opportunity_id]) {
+                    roundsByOpportunity[round.opportunity_id] = [];
+                }
+                roundsByOpportunity[round.opportunity_id].push(round);
+            }
+        }
+
         if (opportunityIds?.length) {
             const foundIds = new Set((opportunities || []).map((opportunity) => opportunity.id));
             const missingIds = opportunityIds.filter((id) => !foundIds.has(id));
@@ -104,10 +128,11 @@ router.post('/', validate(createShareLinkSchema), async (req, res) => {
         }
 
         const snapshot = buildShareSnapshot({
-            opportunities: opportunities || [],
+            opportunities: opportunityList,
             fields,
             expiry,
             selectedOpportunityIds: opportunityIds || [],
+            roundsByOpportunity,
         });
 
         const token = generateShareToken();

--- a/backend/src/routes/upcoming-rounds.js
+++ b/backend/src/routes/upcoming-rounds.js
@@ -1,0 +1,75 @@
+const express = require('express');
+const { supabase } = require('../lib/supabase');
+const { validate } = require('../middleware/validate');
+const { upcomingRoundsQuerySchema } = require('../validation/rounds-schemas');
+
+const router = express.Router();
+
+const isDatabaseUnavailableError = (error) => {
+    const msg = String(error?.message || '').toLowerCase();
+    return msg.includes('fetch failed') || msg.includes('network');
+};
+
+const handleRouteError = (res, action, error, defaultMessage) => {
+    const unavailable = isDatabaseUnavailableError(error);
+
+    console.error(`${action} error:`, {
+        type: 'ROUTE_ERROR',
+        service: 'supabase',
+        unavailable,
+        message: error?.message,
+        code: error?.code,
+    });
+
+    if (unavailable) {
+        return res.status(503).json({
+            error: 'Service Unavailable',
+            message: 'Database is currently unavailable. Please try again in a moment.',
+        });
+    }
+
+    return res.status(500).json({ error: defaultMessage });
+};
+
+/**
+ * GET /api/opportunities/rounds/upcoming?from=YYYY-MM-DD&to=YYYY-MM-DD
+ * Pending interview rounds with scheduled dates in range (internships only).
+ */
+router.get('/upcoming', validate(upcomingRoundsQuerySchema, 'query'), async (req, res) => {
+    try {
+        const userId = req.auth.internalUserId;
+        const { from, to } = req.query;
+
+        const { data, error } = await supabase
+            .from('opportunity_rounds')
+            .select(
+                'id, opportunity_id, round_number, round_type, scheduled_date, result, opportunities!inner(id, title, category)'
+            )
+            .eq('user_id', userId)
+            .eq('result', 'pending')
+            .eq('opportunities.category', 'internship')
+            .not('scheduled_date', 'is', null)
+            .gte('scheduled_date', from)
+            .lte('scheduled_date', to)
+            .order('scheduled_date', { ascending: true })
+            .order('round_number', { ascending: true });
+
+        if (error) throw error;
+
+        const items = (data || []).map((row) => ({
+            id: row.id,
+            opportunityId: row.opportunity_id,
+            opportunityTitle: row.opportunities?.title || 'Internship',
+            roundNumber: row.round_number,
+            roundType: row.round_type,
+            scheduledDate: row.scheduled_date,
+            result: row.result,
+        }));
+
+        res.json(items);
+    } catch (error) {
+        return handleRouteError(res, 'LIST_UPCOMING_ROUNDS', error, 'Failed to fetch upcoming interview rounds');
+    }
+});
+
+module.exports = router;

--- a/backend/src/routes/upcoming-rounds.js
+++ b/backend/src/routes/upcoming-rounds.js
@@ -5,6 +5,8 @@ const { upcomingRoundsQuerySchema } = require('../validation/rounds-schemas');
 
 const router = express.Router();
 
+const UPCOMING_ROUNDS_MAX_RESULTS = 200;
+
 const isDatabaseUnavailableError = (error) => {
     const msg = String(error?.message || '').toLowerCase();
     return msg.includes('fetch failed') || msg.includes('network');
@@ -52,7 +54,8 @@ router.get('/upcoming', validate(upcomingRoundsQuerySchema, 'query'), async (req
             .gte('scheduled_date', from)
             .lte('scheduled_date', to)
             .order('scheduled_date', { ascending: true })
-            .order('round_number', { ascending: true });
+            .order('round_number', { ascending: true })
+            .limit(UPCOMING_ROUNDS_MAX_RESULTS);
 
         if (error) throw error;
 

--- a/backend/src/validation/rounds-schemas.js
+++ b/backend/src/validation/rounds-schemas.js
@@ -120,11 +120,36 @@ const opportunityIdOnlyParamsSchema = Joi.object({
         })
 });
 
+const upcomingRoundsQuerySchema = Joi.object({
+    from: Joi.string()
+        .pattern(/^\d{4}-\d{2}-\d{2}$/)
+        .required()
+        .messages({
+            'string.pattern.base': 'from must be a valid ISO date (YYYY-MM-DD)',
+            'any.required': 'from query parameter is required'
+        }),
+    to: Joi.string()
+        .pattern(/^\d{4}-\d{2}-\d{2}$/)
+        .required()
+        .messages({
+            'string.pattern.base': 'to must be a valid ISO date (YYYY-MM-DD)',
+            'any.required': 'to query parameter is required'
+        })
+}).custom((value, helpers) => {
+    if (value.to < value.from) {
+        return helpers.error('object.dateRange');
+    }
+    return value;
+}).messages({
+    'object.dateRange': 'to must be on or after from'
+});
+
 module.exports = {
     ROUND_TYPES,
     ROUND_RESULTS,
     createRoundSchema,
     updateRoundSchema,
     opportunityRoundParamsSchema,
-    opportunityIdOnlyParamsSchema
+    opportunityIdOnlyParamsSchema,
+    upcomingRoundsQuerySchema
 };

--- a/backend/src/validation/rounds-schemas.js
+++ b/backend/src/validation/rounds-schemas.js
@@ -120,28 +120,56 @@ const opportunityIdOnlyParamsSchema = Joi.object({
         })
 });
 
+const UPCOMING_ROUNDS_MAX_RANGE_DAYS = 366;
+
+const dateOnlyString = Joi.string().custom((value, helpers) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return helpers.error('string.pattern.base');
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+        parsed.getUTCFullYear() !== year ||
+        parsed.getUTCMonth() !== month - 1 ||
+        parsed.getUTCDate() !== day
+    ) {
+        return helpers.error('date.invalid');
+    }
+
+    return value;
+});
+
 const upcomingRoundsQuerySchema = Joi.object({
-    from: Joi.string()
-        .pattern(/^\d{4}-\d{2}-\d{2}$/)
-        .required()
-        .messages({
-            'string.pattern.base': 'from must be a valid ISO date (YYYY-MM-DD)',
-            'any.required': 'from query parameter is required'
-        }),
-    to: Joi.string()
-        .pattern(/^\d{4}-\d{2}-\d{2}$/)
-        .required()
-        .messages({
-            'string.pattern.base': 'to must be a valid ISO date (YYYY-MM-DD)',
-            'any.required': 'to query parameter is required'
-        })
+    from: dateOnlyString.required().messages({
+        'string.pattern.base': 'from must be a valid ISO date (YYYY-MM-DD)',
+        'date.invalid': 'from must be a valid calendar date',
+        'any.required': 'from query parameter is required'
+    }),
+    to: dateOnlyString.required().messages({
+        'string.pattern.base': 'to must be a valid ISO date (YYYY-MM-DD)',
+        'date.invalid': 'to must be a valid calendar date',
+        'any.required': 'to query parameter is required'
+    })
 }).custom((value, helpers) => {
     if (value.to < value.from) {
         return helpers.error('object.dateRange');
     }
+
+    const [fromYear, fromMonth, fromDay] = value.from.split('-').map(Number);
+    const [toYear, toMonth, toDay] = value.to.split('-').map(Number);
+    const fromMs = Date.UTC(fromYear, fromMonth - 1, fromDay);
+    const toMs = Date.UTC(toYear, toMonth - 1, toDay);
+    const rangeDays = Math.round((toMs - fromMs) / (24 * 60 * 60 * 1000));
+
+    if (rangeDays > UPCOMING_ROUNDS_MAX_RANGE_DAYS) {
+        return helpers.error('object.dateRangeTooWide');
+    }
+
     return value;
 }).messages({
-    'object.dateRange': 'to must be on or after from'
+    'object.dateRange': 'to must be on or after from',
+    'object.dateRangeTooWide': `date range cannot exceed ${UPCOMING_ROUNDS_MAX_RANGE_DAYS} days`
 });
 
 module.exports = {
@@ -151,5 +179,6 @@ module.exports = {
     updateRoundSchema,
     opportunityRoundParamsSchema,
     opportunityIdOnlyParamsSchema,
-    upcomingRoundsQuerySchema
+    upcomingRoundsQuerySchema,
+    UPCOMING_ROUNDS_MAX_RANGE_DAYS
 };

--- a/backend/tests/integration/rounds.test.js
+++ b/backend/tests/integration/rounds.test.js
@@ -23,6 +23,9 @@ function listChain(data, error = null) {
     const chain = {
         select: jest.fn(() => chain),
         eq: jest.fn(() => chain),
+        not: jest.fn(() => chain),
+        gte: jest.fn(() => chain),
+        lte: jest.fn(() => chain),
         order: jest.fn(() => chain),
         limit: jest.fn(() => Promise.resolve({ data, error })),
         then: (resolve, reject) => Promise.resolve({ data, error }).then(resolve, reject),
@@ -211,5 +214,53 @@ describe('Interview rounds API', () => {
 
         expect(res.status).toBe(404);
         expect(res.body.error).toBe('Opportunity not found');
+    });
+
+    it('GET /api/opportunities/rounds/upcoming returns 401 without auth', async () => {
+        const res = await request(app).get(
+            '/api/opportunities/rounds/upcoming?from=2026-01-01&to=2026-01-31'
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it('GET /api/opportunities/rounds/upcoming returns pending rounds in date range', async () => {
+        const upcomingData = [
+            {
+                id: ROUND_ID,
+                opportunity_id: OPPORTUNITY_ID,
+                round_number: 2,
+                round_type: 'technical',
+                scheduled_date: '2026-06-15',
+                result: 'pending',
+                opportunities: { id: OPPORTUNITY_ID, title: 'Acme Intern', category: 'internship' },
+            },
+        ];
+
+        mockFrom.mockReturnValue(listChain(upcomingData));
+
+        const res = await request(app)
+            .get('/api/opportunities/rounds/upcoming?from=2026-06-01&to=2026-06-30')
+            .set(authHeader);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveLength(1);
+        expect(res.body[0]).toMatchObject({
+            id: ROUND_ID,
+            opportunityId: OPPORTUNITY_ID,
+            opportunityTitle: 'Acme Intern',
+            roundNumber: 2,
+            roundType: 'technical',
+            scheduledDate: '2026-06-15',
+            result: 'pending',
+        });
+    });
+
+    it('GET /api/opportunities/rounds/upcoming returns 400 when from is after to', async () => {
+        const res = await request(app)
+            .get('/api/opportunities/rounds/upcoming?from=2026-06-30&to=2026-06-01')
+            .set(authHeader);
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('Validation Error');
     });
 });

--- a/backend/tests/integration/rounds.test.js
+++ b/backend/tests/integration/rounds.test.js
@@ -263,4 +263,13 @@ describe('Interview rounds API', () => {
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('Validation Error');
     });
+
+    it('GET /api/opportunities/rounds/upcoming returns 400 for impossible calendar dates', async () => {
+        const res = await request(app)
+            .get('/api/opportunities/rounds/upcoming?from=2026-02-30&to=2026-03-01')
+            .set(authHeader);
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('Validation Error');
+    });
 });

--- a/backend/tests/integration/share-links.test.js
+++ b/backend/tests/integration/share-links.test.js
@@ -162,6 +162,7 @@ describe('Share Links API', () => {
 
         mockFrom
             .mockReturnValueOnce(createChain({ data: opportunities, error: null }))
+            .mockReturnValueOnce(createChain({ data: [], error: null }))
             .mockReturnValueOnce(insertChain);
 
         const res = await request(app)
@@ -196,7 +197,68 @@ describe('Share Links API', () => {
         });
         expect(JSON.stringify(insertedShare.snapshot)).not.toContain('must never leak');
         expect(mockFrom).toHaveBeenCalledWith('opportunities');
+        expect(mockFrom).toHaveBeenCalledWith('opportunity_rounds');
         expect(mockFrom).toHaveBeenCalledWith('share_links');
+    });
+
+    it('POST /api/share-links embeds interview round timelines as snapshot v3', async () => {
+        const opportunities = [
+            {
+                id: OPPORTUNITY_ID,
+                title: 'Backend Intern',
+                category: 'internship',
+                status: 'interviewed',
+                created_at: '2026-06-01T00:00:00.000Z',
+                current_round_number: 2,
+            },
+        ];
+        const rounds = [
+            {
+                opportunity_id: OPPORTUNITY_ID,
+                round_number: 1,
+                round_type: 'oa',
+                scheduled_date: '2026-06-10',
+                result: 'cleared',
+                notes: 'private notes',
+            },
+            {
+                opportunity_id: OPPORTUNITY_ID,
+                round_number: 2,
+                round_type: 'technical',
+                scheduled_date: null,
+                result: 'pending',
+            },
+        ];
+        const insertChain = createChain({ data: shareRow({ view_count: 0 }), error: null });
+
+        mockFrom
+            .mockReturnValueOnce(createChain({ data: opportunities, error: null }))
+            .mockReturnValueOnce(createChain({ data: rounds, error: null }))
+            .mockReturnValueOnce(insertChain);
+
+        const res = await request(app)
+            .post('/api/share-links')
+            .set(authHeader)
+            .send({ expiry: '7d', fields: { rounds: true, status: true } });
+
+        expect(res.status).toBe(201);
+        const snapshot = insertChain.insert.mock.calls[0][0].snapshot;
+        expect(snapshot.version).toBe(3);
+        expect(snapshot.opportunities[0].interviewRounds).toEqual([
+            {
+                roundNumber: 1,
+                roundType: 'oa',
+                scheduledDate: '2026-06-10',
+                result: 'cleared',
+            },
+            {
+                roundNumber: 2,
+                roundType: 'technical',
+                scheduledDate: null,
+                result: 'pending',
+            },
+        ]);
+        expect(JSON.stringify(snapshot)).not.toContain('private notes');
     });
 
     it('POST /api/share-links creates a specific-opportunity share snapshot', async () => {
@@ -219,6 +281,7 @@ describe('Share Links API', () => {
 
         mockFrom
             .mockReturnValueOnce(opportunitiesChain)
+            .mockReturnValueOnce(createChain({ data: [], error: null }))
             .mockReturnValueOnce(insertChain);
 
         const res = await request(app)

--- a/backend/tests/unit/interviewPipelineAnalytics.test.js
+++ b/backend/tests/unit/interviewPipelineAnalytics.test.js
@@ -95,4 +95,30 @@ describe('buildInterviewPipelineAnalytics', () => {
             count: 2
         });
     });
+
+    it('builds funnel metrics by round type and stage reach by round number', () => {
+        const result = buildInterviewPipelineAnalytics(
+            [
+                { id: 'i1', title: 'A', category: 'internship', status: 'interviewed' },
+                { id: 'i2', title: 'B', category: 'internship', status: 'rejected', rejected_round_number: 2 },
+            ],
+            [
+                { opportunity_id: 'i1', round_number: 1, round_type: 'oa', result: 'cleared' },
+                { opportunity_id: 'i1', round_number: 2, round_type: 'technical', result: 'pending' },
+                { opportunity_id: 'i2', round_number: 1, round_type: 'oa', result: 'cleared' },
+                { opportunity_id: 'i2', round_number: 2, round_type: 'technical', result: 'rejected' },
+            ]
+        );
+
+        expect(result.funnelByRoundType).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ roundType: 'oa', reached: 2, cleared: 2, rejected: 0 }),
+                expect.objectContaining({ roundType: 'technical', reached: 2, cleared: 0, rejected: 1 }),
+            ])
+        );
+        expect(result.stageReachByRoundNumber).toEqual([
+            { roundNumber: 1, reached: 2, stillActive: 0 },
+            { roundNumber: 2, reached: 2, stillActive: 1 },
+        ]);
+    });
 });

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import Home from './pages/Home'; // Landing page - load immediately for best UX
 
 // Hooks
 import { useAuthToken } from './hooks/useAuthToken';
+import { useInterviewReminders } from './hooks/useInterviewReminders';
 
 // Analytics
 import { trackPageView, identifyUser, resetAnalytics } from './lib/analytics';
@@ -49,6 +50,7 @@ function AppContent() {
 
   // Initialize auth token getter for API calls
   useAuthToken();
+  useInterviewReminders();
 
   // Track page views on route changes (redact public share tokens)
   useEffect(() => {

--- a/src/components/analytics/InterviewFunnelChart.jsx
+++ b/src/components/analytics/InterviewFunnelChart.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { FaFilter } from 'react-icons/fa';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import Card from '../common/Card';
+
+const FUNNEL_COLORS = {
+  reached: '#6366F1',
+  cleared: '#22C55E',
+  rejected: '#EF4444',
+};
+
+/**
+ * Pipeline funnel by round type — reach vs clear vs reject.
+ */
+const InterviewFunnelChart = ({ pipeline, compact = false }) => {
+  const funnel = pipeline?.funnelByRoundType || [];
+
+  if (!funnel.length) {
+    return (
+      <Card className={compact ? 'p-4' : 'p-6'}>
+        <h3 className={`font-semibold text-white mb-2 flex items-center gap-2 ${compact ? 'text-base' : 'text-lg'}`}>
+          <FaFilter className="text-indigo-400" />
+          Pipeline funnel by round type
+        </h3>
+        <p className="text-sm text-gray-400">
+          Log interview rounds on internships to see how far you progress through each stage type.
+        </p>
+      </Card>
+    );
+  }
+
+  const chartData = funnel.map((item) => ({
+    name: item.label.length > 14 ? `${item.label.slice(0, 12)}…` : item.label,
+    fullName: item.label,
+    reached: item.reached,
+    cleared: item.cleared,
+    rejected: item.rejected,
+    clearanceRate: item.clearanceRate,
+  }));
+
+  const chartHeight = compact ? 'h-48' : 'h-64';
+
+  return (
+    <Card className={compact ? 'p-4' : 'p-6'}>
+      <h3 className={`font-semibold text-white mb-1 flex items-center gap-2 ${compact ? 'text-base' : 'text-lg'}`}>
+        <FaFilter className="text-indigo-400" />
+        Pipeline funnel by round type
+      </h3>
+      <p className="text-sm text-gray-400 mb-4">
+        How many internships reached each stage, and how many cleared vs were rejected there.
+      </p>
+
+      <div className={chartHeight}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+            <XAxis dataKey="name" tick={{ fill: '#9CA3AF', fontSize: 11 }} />
+            <YAxis allowDecimals={false} tick={{ fill: '#9CA3AF', fontSize: 11 }} />
+            <Tooltip
+              contentStyle={{ backgroundColor: '#111827', border: '1px solid #374151' }}
+              labelFormatter={(_, payload) => payload?.[0]?.payload?.fullName || ''}
+              formatter={(value, name) => [value, name === 'reached' ? 'Reached' : name === 'cleared' ? 'Cleared' : 'Rejected']}
+            />
+            <Legend />
+            <Bar dataKey="reached" name="Reached" fill={FUNNEL_COLORS.reached} radius={[4, 4, 0, 0]} />
+            <Bar dataKey="cleared" name="Cleared" fill={FUNNEL_COLORS.cleared} radius={[4, 4, 0, 0]} />
+            <Bar dataKey="rejected" name="Rejected" fill={FUNNEL_COLORS.rejected} radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {!compact && pipeline.stageReachByRoundNumber?.length > 0 && (
+        <div className="mt-6 border-t border-white/10 pt-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">By round number</p>
+          <div className="flex flex-wrap gap-2">
+            {pipeline.stageReachByRoundNumber.map((stage) => (
+              <span
+                key={stage.roundNumber}
+                className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300"
+              >
+                R{stage.roundNumber}: {stage.reached} reached
+                {stage.stillActive > 0 ? ` · ${stage.stillActive} pending` : ''}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default InterviewFunnelChart;

--- a/src/components/analytics/InterviewFunnelChart.jsx
+++ b/src/components/analytics/InterviewFunnelChart.jsx
@@ -66,9 +66,25 @@ const InterviewFunnelChart = ({ pipeline, compact = false }) => {
             <XAxis dataKey="name" tick={{ fill: '#9CA3AF', fontSize: 11 }} />
             <YAxis allowDecimals={false} tick={{ fill: '#9CA3AF', fontSize: 11 }} />
             <Tooltip
-              contentStyle={{ backgroundColor: '#111827', border: '1px solid #374151' }}
-              labelFormatter={(_, payload) => payload?.[0]?.payload?.fullName || ''}
-              formatter={(value, name) => [value, name === 'reached' ? 'Reached' : name === 'cleared' ? 'Cleared' : 'Rejected']}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) {
+                  return null;
+                }
+
+                const data = payload[0].payload;
+
+                return (
+                  <div className="rounded-lg border border-gray-700 bg-gray-900 p-3 text-sm text-gray-200">
+                    <p className="mb-2 font-medium text-white">{data.fullName}</p>
+                    <p>Reached: {data.reached}</p>
+                    <p>Cleared: {data.cleared}</p>
+                    <p>Rejected: {data.rejected}</p>
+                    {data.clearanceRate != null && (
+                      <p className="mt-1 text-gray-400">Clearance rate: {data.clearanceRate}%</p>
+                    )}
+                  </div>
+                );
+              }}
             />
             <Legend />
             <Bar dataKey="reached" name="Reached" fill={FUNNEL_COLORS.reached} radius={[4, 4, 0, 0]} />

--- a/src/components/dashboard/UpcomingInterviewsWidget.jsx
+++ b/src/components/dashboard/UpcomingInterviewsWidget.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FaLayerGroup, FaCalendarCheck } from 'react-icons/fa';
+import Card from '../common/Card';
+import { formatDate, getDaysRemaining } from '../../utils/dateHelpers';
+import { getRoundTypeLabel } from '../../utils/roundHelpers';
+
+const UpcomingInterviewsWidget = ({ interviews = [], loading = false }) => {
+  const navigate = useNavigate();
+
+  const hasUrgent = interviews.some((item) => {
+    const days = getDaysRemaining(item.scheduledDate);
+    return days >= 0 && days <= 1;
+  });
+
+  if (loading) {
+    return (
+      <Card className="p-4 sm:p-6 animate-pulse">
+        <div className="h-6 w-48 bg-white/10 rounded mb-4" />
+        <div className="space-y-3">
+          <div className="h-14 bg-white/5 rounded-lg" />
+          <div className="h-14 bg-white/5 rounded-lg" />
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4 sm:p-6">
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <h3 className="text-base sm:text-lg font-semibold text-white flex items-center">
+          <FaLayerGroup className="mr-2 text-purple-400" />
+          Upcoming Interviews
+        </h3>
+        {hasUrgent && (
+          <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-200">
+            <FaCalendarCheck size={10} aria-hidden="true" />
+            Soon
+          </span>
+        )}
+      </div>
+
+      {interviews.length === 0 ? (
+        <p className="text-gray-400 text-center py-4 text-sm">
+          No scheduled interview rounds. Add a date when you log a pending round on an internship.
+        </p>
+      ) : (
+        <div className="space-y-2 sm:space-y-3">
+          {interviews.slice(0, 5).map((item) => {
+            const days = getDaysRemaining(item.scheduledDate);
+            const urgencyClass =
+              days < 0
+                ? 'border-gray-500/40 bg-gray-500/10'
+                : days <= 1
+                  ? 'border-amber-500/40 bg-amber-500/10'
+                  : days <= 3
+                    ? 'border-purple-500/40 bg-purple-500/10'
+                    : 'border-blue-500/40 bg-blue-500/10';
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => navigate('/internships')}
+                className={`w-full text-left rounded-lg border-l-4 p-3 transition-all hover:brightness-110 ${urgencyClass}`}
+              >
+                <p className="font-medium text-white text-sm truncate">{item.opportunityTitle}</p>
+                <p className="text-xs text-gray-300 mt-1">
+                  Round {item.roundNumber} · {getRoundTypeLabel(item.roundType)}
+                </p>
+                <p className="text-xs text-gray-400 mt-1">
+                  {formatDate(item.scheduledDate)}
+                  {days === 0 && ' · Today'}
+                  {days === 1 && ' · Tomorrow'}
+                  {days > 1 && ` · In ${days} days`}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default UpcomingInterviewsWidget;

--- a/src/components/rounds/RoundTimelineReadOnly.jsx
+++ b/src/components/rounds/RoundTimelineReadOnly.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { formatDate } from '../../utils/dateHelpers';
+import {
+  getRoundResultLabel,
+  getRoundTypeLabel,
+  ROUND_RESULT_STYLES,
+} from '../../utils/roundHelpers';
+
+/**
+ * Compact read-only round stepper for public share pages.
+ */
+const RoundTimelineReadOnly = ({ rounds = [] }) => {
+  if (!rounds.length) {
+    return null;
+  }
+
+  const sorted = [...rounds].sort((a, b) => a.roundNumber - b.roundNumber);
+
+  return (
+    <ol className="mt-4 space-y-2" aria-label="Interview pipeline">
+      {sorted.map((round) => (
+        <li
+          key={`${round.roundNumber}-${round.roundType}`}
+          className="flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-sm"
+        >
+          <span className="font-medium text-white">Round {round.roundNumber}</span>
+          <span className="text-gray-400">·</span>
+          <span className="text-gray-300">{getRoundTypeLabel(round.roundType)}</span>
+          {round.scheduledDate && (
+            <>
+              <span className="text-gray-500">·</span>
+              <span className="text-gray-400">{formatDate(round.scheduledDate)}</span>
+            </>
+          )}
+          <span
+            className={`ml-auto rounded-full border px-2 py-0.5 text-xs font-medium ${
+              ROUND_RESULT_STYLES[round.result] || 'bg-gray-500/10 text-gray-400 border-gray-500/20'
+            }`}
+          >
+            {getRoundResultLabel(round.result)}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+export default RoundTimelineReadOnly;

--- a/src/hooks/useInterviewReminders.js
+++ b/src/hooks/useInterviewReminders.js
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react';
+import { useUser } from '@clerk/clerk-react';
+import { toast } from 'react-toastify';
+import { roundService } from '../services/api';
+import { getRoundTypeLabel } from '../utils/roundHelpers';
+
+const REMINDER_PREF_KEY = 'futurestack_interview_reminders';
+const REMINDER_HOUR = 9;
+
+function toDateKey(dateStr) {
+  return dateStr;
+}
+
+function getReminderFireTime(scheduledDate, kind) {
+  const base = new Date(`${scheduledDate}T00:00:00`);
+  if (kind === 'day_before') {
+    base.setDate(base.getDate() - 1);
+  }
+  base.setHours(REMINDER_HOUR, 0, 0, 0);
+  return base.getTime();
+}
+
+function scheduleNotification({ id, title, body, fireAt }) {
+  const delay = fireAt - Date.now();
+  if (delay <= 0 || delay > 7 * 24 * 60 * 60 * 1000) {
+    return null;
+  }
+
+  const sessionKey = `reminder:${id}`;
+  if (sessionStorage.getItem(sessionKey)) {
+    return null;
+  }
+
+  return setTimeout(() => {
+    sessionStorage.setItem(sessionKey, '1');
+
+    if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+      new Notification(title, { body, tag: id });
+    } else {
+      toast.info(body, { autoClose: 8000 });
+    }
+  }, delay);
+}
+
+/**
+ * Client-side interview reminders for pending rounds with scheduled dates.
+ */
+export function useInterviewReminders() {
+  const { isSignedIn } = useUser();
+  const timersRef = useRef([]);
+
+  useEffect(() => {
+    if (!isSignedIn) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const setup = async () => {
+      try {
+        const today = new Date();
+        const from = new Date(today);
+        from.setDate(from.getDate() - 1);
+        const to = new Date(today);
+        to.setDate(to.getDate() + 14);
+
+        const fromStr = from.toISOString().slice(0, 10);
+        const toStr = to.toISOString().slice(0, 10);
+
+        const rounds = await roundService.listUpcoming({ from: fromStr, to: toStr });
+        if (cancelled) return;
+
+        const pref = localStorage.getItem(REMINDER_PREF_KEY);
+        if (pref !== 'off' && typeof Notification !== 'undefined' && Notification.permission === 'default') {
+          Notification.requestPermission().then((result) => {
+            localStorage.setItem(REMINDER_PREF_KEY, result === 'denied' ? 'off' : 'on');
+          });
+        }
+
+        timersRef.current.forEach(clearTimeout);
+        timersRef.current = [];
+
+        for (const round of rounds) {
+          const typeLabel = getRoundTypeLabel(round.roundType);
+          const baseBody = `${round.opportunityTitle} — Round ${round.roundNumber} (${typeLabel})`;
+
+          const dayBeforeId = `${round.id}:day_before`;
+          const morningId = `${round.id}:morning`;
+
+          const dayBeforeTimer = scheduleNotification({
+            id: dayBeforeId,
+            title: 'Interview tomorrow',
+            body: baseBody,
+            fireAt: getReminderFireTime(toDateKey(round.scheduledDate), 'day_before'),
+          });
+
+          const morningTimer = scheduleNotification({
+            id: morningId,
+            title: 'Interview today',
+            body: baseBody,
+            fireAt: getReminderFireTime(toDateKey(round.scheduledDate), 'morning'),
+          });
+
+          if (dayBeforeTimer) timersRef.current.push(dayBeforeTimer);
+          if (morningTimer) timersRef.current.push(morningTimer);
+        }
+      } catch (error) {
+        console.error('Interview reminders setup failed:', error);
+      }
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+    };
+  }, [isSignedIn]);
+}

--- a/src/hooks/useInterviewReminders.js
+++ b/src/hooks/useInterviewReminders.js
@@ -62,7 +62,7 @@ export function useInterviewReminders() {
         const from = new Date(today);
         from.setDate(from.getDate() - 1);
         const to = new Date(today);
-        to.setDate(to.getDate() + 14);
+        to.setDate(to.getDate() + 7);
 
         const fromStr = from.toISOString().slice(0, 10);
         const toStr = to.toISOString().slice(0, 10);

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -10,6 +10,7 @@ import Card from '../components/common/Card';
 import EmptyState from '../components/common/EmptyState';
 import { SkeletonChart } from '../components/common/LoadingSpinner';
 import InterviewRejectionInsights from '../components/analytics/InterviewRejectionInsights';
+import InterviewFunnelChart from '../components/analytics/InterviewFunnelChart';
 import { analyticsService } from '../services/api';
 
 const Analytics = () => {
@@ -433,6 +434,9 @@ const Analytics = () => {
                         </p>
                     </div>
                     <InterviewRejectionInsights pipeline={analytics.pipelineAnalytics} />
+                    <div className="mt-6">
+                        <InterviewFunnelChart pipeline={analytics.pipelineAnalytics} />
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -4,32 +4,45 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import './Calendar.css';
 import SEO from '../components/seo/SEO';
-import { opportunityService } from '../services/api';
+import { opportunityService, roundService } from '../services/api';
 import { getDaysRemaining } from '../utils/dateHelpers';
+import { getRoundTypeLabel } from '../utils/roundHelpers';
 import Modal from '../components/common/Modal';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
-import { FaBriefcase, FaCode, FaCalendarAlt, FaClock } from 'react-icons/fa';
+import { FaBriefcase, FaCode, FaCalendarAlt, FaClock, FaLayerGroup } from 'react-icons/fa';
 
 const CalendarPage = () => {
   const [opportunities, setOpportunities] = useState([]);
+  const [upcomingRounds, setUpcomingRounds] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showModal, setShowModal] = useState(false);
   const [selectedDateOpportunities, setSelectedDateOpportunities] = useState([]);
+  const [selectedDateRounds, setSelectedDateRounds] = useState([]);
 
   useEffect(() => {
-    fetchOpportunities();
+    fetchData();
   }, []);
 
-  const fetchOpportunities = async () => {
+  const fetchData = async () => {
     try {
       setLoading(true);
-      const data = await opportunityService.getAll();
-      setOpportunities(data);
+      const today = new Date();
+      const from = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+      const to = new Date(today.getFullYear(), today.getMonth() + 3, 0);
+      const fromStr = from.toISOString().slice(0, 10);
+      const toStr = to.toISOString().slice(0, 10);
+
+      const [opps, rounds] = await Promise.all([
+        opportunityService.getAll(),
+        roundService.listUpcoming({ from: fromStr, to: toStr }),
+      ]);
+      setOpportunities(opps);
+      setUpcomingRounds(rounds);
     } catch (error) {
-      console.error('Error fetching opportunities:', error);
-      toast.error('Failed to load opportunities');
+      console.error('Error fetching calendar data:', error);
+      toast.error('Failed to load calendar');
     } finally {
       setLoading(false);
     }
@@ -47,24 +60,43 @@ const CalendarPage = () => {
     }
   });
 
-  // Function to mark dates with deadlines
+  const interviewMap = {};
+  upcomingRounds.forEach((round) => {
+    if (round.scheduledDate) {
+      const dateKey = new Date(`${round.scheduledDate}T12:00:00`).toDateString();
+      if (!interviewMap[dateKey]) {
+        interviewMap[dateKey] = [];
+      }
+      interviewMap[dateKey].push(round);
+    }
+  });
+
+  // Function to mark dates with deadlines and interviews
   const tileContent = ({ date, view }) => {
     if (view === 'month') {
       const dateKey = date.toDateString();
       const oppsOnDate = deadlineMap[dateKey];
+      const roundsOnDate = interviewMap[dateKey];
 
-      if (oppsOnDate && oppsOnDate.length > 0) {
-        // Count internships and hackathons
-        const internships = oppsOnDate.filter(opp => opp.category === 'internship').length;
-        const hackathons = oppsOnDate.filter(opp => opp.category === 'hackathon').length;
+      if ((oppsOnDate && oppsOnDate.length > 0) || (roundsOnDate && roundsOnDate.length > 0)) {
+        const internships = oppsOnDate
+          ? oppsOnDate.filter((opp) => opp.category === 'internship').length
+          : 0;
+        const hackathons = oppsOnDate
+          ? oppsOnDate.filter((opp) => opp.category === 'hackathon').length
+          : 0;
+        const interviews = roundsOnDate ? roundsOnDate.length : 0;
 
         return (
           <div className="flex justify-center items-center gap-1 mt-1">
             {internships > 0 && (
-              <div className="w-2 h-2 bg-blue-500 rounded-full" title={`${internships} internship(s)`} />
+              <div className="w-2 h-2 bg-blue-500 rounded-full" title={`${internships} internship deadline(s)`} />
             )}
             {hackathons > 0 && (
-              <div className="w-2 h-2 bg-green-500 rounded-full" title={`${hackathons} hackathon(s)`} />
+              <div className="w-2 h-2 bg-green-500 rounded-full" title={`${hackathons} hackathon deadline(s)`} />
+            )}
+            {interviews > 0 && (
+              <div className="w-2 h-2 bg-purple-500 rounded-full" title={`${interviews} interview round(s)`} />
             )}
           </div>
         );
@@ -78,9 +110,11 @@ const CalendarPage = () => {
     setSelectedDate(date);
     const dateKey = date.toDateString();
     const oppsOnDate = deadlineMap[dateKey] || [];
+    const roundsOnDate = interviewMap[dateKey] || [];
 
-    if (oppsOnDate.length > 0) {
+    if (oppsOnDate.length > 0 || roundsOnDate.length > 0) {
       setSelectedDateOpportunities(oppsOnDate);
+      setSelectedDateRounds(roundsOnDate);
       setShowModal(true);
     }
   };
@@ -135,6 +169,10 @@ const CalendarPage = () => {
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 bg-green-500 rounded-full" />
               <span className="text-gray-300 text-sm">Hackathon Deadline</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 bg-purple-500 rounded-full" />
+              <span className="text-gray-300 text-sm">Interview Round</span>
             </div>
             <div className="flex items-center gap-2">
               <FaCalendarAlt className="text-gray-400" />
@@ -194,10 +232,30 @@ const CalendarPage = () => {
         <Modal
           isOpen={showModal}
           onClose={() => setShowModal(false)}
-          title={`Opportunities on ${selectedDate.toLocaleDateString()}`}
+          title={`Events on ${selectedDate.toLocaleDateString()}`}
           className="max-w-2xl"
         >
           <div className="space-y-4">
+            {selectedDateRounds.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="text-sm font-semibold text-purple-300 flex items-center gap-2">
+                  <FaLayerGroup />
+                  Interview rounds
+                </h4>
+                {selectedDateRounds.map((round) => (
+                  <div
+                    key={round.id}
+                    className="bg-purple-900/20 rounded-lg p-3 border border-purple-500/30"
+                  >
+                    <p className="text-white font-medium">{round.opportunityTitle}</p>
+                    <p className="text-sm text-gray-300 mt-1">
+                      Round {round.roundNumber} · {getRoundTypeLabel(round.roundType)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+
             {selectedDateOpportunities.map(opp => (
               <div
                 key={opp.id}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,16 +5,19 @@ import { FaClipboardList, FaStar, FaCheckCircle, FaPlus, FaList, FaTrash } from 
 import SEO from '../components/seo/SEO';
 import StatsCard from '../components/dashboard/StatsCard';
 import DeadlineWidget from '../components/dashboard/DeadlineWidget';
+import UpcomingInterviewsWidget from '../components/dashboard/UpcomingInterviewsWidget';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import Modal from '../components/common/Modal';
 import ShareProgressModal from '../components/sharing/ShareProgressModal';
 import ManageSharesPanel from '../components/sharing/ManageSharesPanel';
-import { opportunityService } from '../services/api';
+import { opportunityService, roundService } from '../services/api';
 import { isOverdue, getDaysRemaining } from '../utils/dateHelpers';
 
 const Dashboard = () => {
   const [opportunities, setOpportunities] = useState([]);
+  const [upcomingInterviews, setUpcomingInterviews] = useState([]);
+  const [interviewsLoading, setInterviewsLoading] = useState(true);
   const [loading, setLoading] = useState(true);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [opportunityToDelete, setOpportunityToDelete] = useState(null);
@@ -24,7 +27,25 @@ const Dashboard = () => {
 
   useEffect(() => {
     fetchOpportunities();
+    fetchUpcomingInterviews();
   }, []);
+
+  const fetchUpcomingInterviews = async () => {
+    try {
+      setInterviewsLoading(true);
+      const today = new Date();
+      const to = new Date(today);
+      to.setDate(to.getDate() + 30);
+      const fromStr = today.toISOString().slice(0, 10);
+      const toStr = to.toISOString().slice(0, 10);
+      const rounds = await roundService.listUpcoming({ from: fromStr, to: toStr });
+      setUpcomingInterviews(rounds);
+    } catch (error) {
+      console.error('Error fetching upcoming interviews:', error);
+    } finally {
+      setInterviewsLoading(false);
+    }
+  };
 
   const fetchOpportunities = async () => {
     try {
@@ -201,9 +222,10 @@ const Dashboard = () => {
           </Card>
         )}
 
-        {/* Upcoming Deadlines */}
-        <div className="mb-6 sm:mb-8">
+        {/* Upcoming deadlines & interviews */}
+        <div className="mb-6 sm:mb-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
           <DeadlineWidget deadlines={upcomingDeadlines} onDelete={handleDeleteClick} />
+          <UpcomingInterviewsWidget interviews={upcomingInterviews} loading={interviewsLoading} />
         </div>
 
         {/* Quick Actions */}

--- a/src/pages/PublicSharePage.jsx
+++ b/src/pages/PublicSharePage.jsx
@@ -14,6 +14,7 @@ import SEO from '../components/seo/SEO';
 import Button from '../components/common/Button';
 import Card from '../components/common/Card';
 import LoadingSpinner from '../components/common/LoadingSpinner';
+import RoundTimelineReadOnly from '../components/rounds/RoundTimelineReadOnly';
 import { shareLinkService } from '../services/api';
 import { formatDate, getDaysRemaining } from '../utils/dateHelpers';
 
@@ -342,6 +343,10 @@ const PublicSharePage = () => {
                         </div>
                       )}
                     </div>
+
+                    {fields.rounds && opportunity.interviewRounds?.length > 0 && (
+                      <RoundTimelineReadOnly rounds={opportunity.interviewRounds} />
+                    )}
 
                     {fields.applicationLink && opportunity.applicationLink && (
                       <div className="mt-5">

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -12,6 +12,7 @@ import SEO from '../components/seo/SEO';
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import InterviewRejectionInsights from '../components/analytics/InterviewRejectionInsights';
+import InterviewFunnelChart from '../components/analytics/InterviewFunnelChart';
 import StatusIndicator from '../components/common/StatusIndicator';
 import { opportunityService, analyticsService } from '../services/api';
 import { generatePDF, downloadPDF } from '../utils/pdfExport';
@@ -450,6 +451,9 @@ const Reports = () => {
             showMetrics={false}
             showCharts={showPipelineSection}
           />
+          {showPipelineSection && (
+            <InterviewFunnelChart pipeline={displayPipeline} compact />
+          )}
         </section>
 
         <div className="flex justify-end pt-2">

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -132,6 +132,13 @@ export const roundService = {
     );
     return response.data;
   },
+
+  listUpcoming: async ({ from, to }) => {
+    const response = await api.get('/opportunities/rounds/upcoming', {
+      params: { from, to },
+    });
+    return response.data;
+  },
 };
 
 export const opportunityService = {


### PR DESCRIPTION
## Summary
- Adds `GET /api/opportunities/rounds/upcoming` with route wiring in `opportunities.js`, `YYYY-MM-DD` query validation in `rounds-schemas.js`, and integration tests in `rounds.test.js`.
- Integrates upcoming interview rounds into Calendar (purple markers + date modal) and Dashboard (`UpcomingInterviewsWidget` + `useInterviewReminders` browser/toast reminders).
- Extends pipeline analytics with `funnelByRoundType` / `stageReachByRoundNumber` and surfaces them via `InterviewFunnelChart` on Analytics and Reports.
- Embeds read-only interview timelines in share snapshots v3 (`interviewRounds` on public opportunities) and renders them on `PublicSharePage`.

## Test plan
- [x] `cd backend && npm test` — 117 passed
- [x] `npm run test:ci` — 23 passed
- [ ] Sign in locally; confirm Dashboard upcoming interviews loads (no 404/500 on `/api/opportunities/rounds/upcoming`)
- [ ] Calendar shows purple dots for scheduled pending rounds
- [ ] Analytics/Reports show funnel chart when rounds exist on internships
- [ ] Create a share link with rounds enabled; public page shows read-only timeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “upcoming rounds” view and API for pending internship interview rounds, surfaced on the Dashboard, Calendar, and Public Share pages.
  * Introduced an Interview Funnel chart (round-type funnel + by-round stage reach) in Analytics/Reports.
  * Added reminder notifications for upcoming interviews.
* **Bug Fixes**
  * Share snapshots now embed read-only interview round timelines when requested, with automatic snapshot versioning.
  * Improved validation and error responses for upcoming round date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->