### PR TITLE
enhancement: replace horizontal scrolling with responsive status board grid

### DIFF
--- a/src/components/statusboard/StatusColumn.jsx
+++ b/src/components/statusboard/StatusColumn.jsx
@@ -45,7 +45,7 @@ const StatusColumn = ({ status, opportunities, onStatusChange, onDelete }) => {
   const count = opportunities.length;
 
   return (
-    <div className="flex-shrink-0 w-72 sm:w-80">
+    <div className="w-full">
       {/* Column Header */}
       <div className={`${config.headerColor} text-white rounded-t-lg p-3 sm:p-4`}>
         <h3 className="font-semibold text-base sm:text-lg flex items-center justify-between">
@@ -57,7 +57,7 @@ const StatusColumn = ({ status, opportunities, onStatusChange, onDelete }) => {
       </div>
 
       {/* Column Content */}
-      <div className={`${config.color} border-2 border-t-0 rounded-b-lg p-3 sm:p-4 min-h-[400px] max-h-[600px] overflow-y-auto`}>
+      <div className={`${config.color} border-2 border-t-0 rounded-b-lg p-3 sm:p-4 min-h-[350px] max-h-[550px] overflow-y-auto`}>
         {opportunities.length === 0 ? (
           <p className="text-gray-400 text-sm text-center py-8">No opportunities</p>
         ) : (

--- a/src/pages/StatusBoard.jsx
+++ b/src/pages/StatusBoard.jsx
@@ -195,7 +195,7 @@ const StatusBoard = () => {
 
       {/* Status Board - Horizontal scrollable on mobile, side-by-side on desktop */}
       <div className="pb-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-start">
           <StatusColumn
             status="applied"
             opportunities={groupedOpportunities.applied}

--- a/src/pages/StatusBoard.jsx
+++ b/src/pages/StatusBoard.jsx
@@ -195,7 +195,7 @@ const StatusBoard = () => {
 
       {/* Status Board - Horizontal scrollable on mobile, side-by-side on desktop */}
       <div className="pb-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-start">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
           <StatusColumn
             status="applied"
             opportunities={groupedOpportunities.applied}

--- a/src/pages/StatusBoard.jsx
+++ b/src/pages/StatusBoard.jsx
@@ -194,8 +194,8 @@ const StatusBoard = () => {
       </div>
 
       {/* Status Board - Horizontal scrollable on mobile, side-by-side on desktop */}
-      <div className="overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0">
-        <div className="flex gap-3 sm:gap-4 min-w-max lg:justify-start">
+      <div className="pb-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
           <StatusColumn
             status="applied"
             opportunities={groupedOpportunities.applied}


### PR DESCRIPTION
## Summary

Improves the Status Board layout by replacing the single-row horizontal layout with a responsive CSS Grid. This enhancement removes unnecessary horizontal scrolling, provides a balanced multi-row layout across different screen sizes, and preserves all existing Kanban functionality.

Fixes #67

## Type of change

* [ ] Bug fix
* [ ] New feature
* [x] Refactor (no behavior change)
* [ ] Documentation

## Changes made

* Updated **`src/pages/StatusBoard.jsx`** to replace the horizontal flex layout with a responsive CSS Grid for improved multi-row responsiveness.
* Updated **`src/components/statusboard/StatusColumn.jsx`** to remove fixed-width constraints, allowing columns to resize responsively within the grid layout.
* Eliminated unnecessary horizontal scrolling on desktop screens while maintaining a balanced layout across desktop, tablet, and mobile devices.
* Preserved all existing Status Board functionality, including status updates, drag-and-drop behavior, and opportunity management.


## Test plan

* [x] `npm run test:ci` passes (frontend)
* [ ] `cd backend && npm test` passes (if API/backend changed)
* [ ] Backend tests added/updated (if API changed)
* [ ] `npm run check:architecture` passes locally
* [x] Tested locally with backend running (`cd backend && npm run dev`)
* [x] Signed in and smoke-tested the Status Board page
* [x] Checked mobile / responsive layout
* [x] No secrets or `.env` files committed

## Screenshots / recording

### Before

* All five status columns were displayed in a single horizontal row.
* Horizontal scrolling was required on desktop screens.
<img width="1861" height="967" alt="Screenshot 2026-06-27 200305" src="https://github.com/user-attachments/assets/2374877d-959a-41be-ba44-9a760b7936c1" />


### After

* Desktop: Three responsive columns in the first row with remaining columns wrapping naturally to the second row.
<img width="1918" height="960" alt="Screenshot 2026-06-28 065842" src="https://github.com/user-attachments/assets/6de618a1-e47a-496d-8e64-b741904a29fd" />



* Tablet: Two responsive columns per row.
<img width="617" height="820" alt="Screenshot 2026-06-28 065918" src="https://github.com/user-attachments/assets/d9e89b7e-1298-4f2d-b299-a8560fea157c" />



* Mobile: Single-column stacked layout.
<img width="292" height="610" alt="Screenshot 2026-06-28 065958" src="https://github.com/user-attachments/assets/a12b12ac-5279-47fc-9305-b6a7a151339c" />


* Horizontal scrolling removed while maintaining consistent spacing and alignment.

## Checklist

* [x] PR addresses **one** assigned issue only
* [x] Acceptance criteria from the issue are met
* [x] Follows existing code style and patterns in this repo
* [ ] Database migrations added under `docs/` if schema changed *(Not applicable)*
* [x] No `console.log` debug noise left behind
* [x] Read [[docs/TESTING.md](https://chatgpt.com/c/docs/TESTING.md)](docs/TESTING.md) if unsure what CI expects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/Layout Improvements**
  * Updated the status board to use a responsive CSS grid layout instead of horizontal scrolling, improving how columns wrap across screen sizes.
  * Changed status columns to better use available width for more consistent alignment.
  * Refined the status list’s vertical space by adjusting its min/max height constraints for a more compact set of visible status cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->