### PR TITLE
feat: add Progress Logger schema and RLS

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -50,6 +50,7 @@ Career applications are fragmented across job boards, messages, spreadsheets, do
 | Hackathon collaboration | Available | Team, members, ideas/votes, tasks, and checklist are separate, user-owned resources. |
 | Read-only share links | Available | A stored snapshot is shared, not live dashboard access. Links can expire, be revoked, and require a passcode. |
 | AI Resume Checker | Implemented, UI-gated | Backend pipeline, storage, provider settings, tests, and UI components exist; `AI_RESUME_CHECK_ENABLED` is currently `false`. |
+| Progress Logger | Schema migration ready | Tracks and daily logs, indexes, and Clerk-compatible RLS are defined; API and UI remain separate follow-on work. |
 | Reminders, tags, bulk import/export, advanced filters | Planned | These are intentionally not claimed as shipped features. |
 
 ## 3. System architecture
@@ -206,6 +207,7 @@ erDiagram
   USERS ||--o{ OPPORTUNITIES : owns
   USERS ||--o{ DOCUMENTS : owns
   USERS ||--o{ SHARE_LINKS : creates
+  USERS ||--o{ PROGRESS_TRACKS : owns
   USERS ||--o| USER_AI_SETTINGS : configures
   OPPORTUNITIES ||--o{ OPPORTUNITY_ROUNDS : contains
   OPPORTUNITIES ||--o{ OPPORTUNITY_DOCUMENTS : uses
@@ -220,6 +222,7 @@ erDiagram
   HACKATHON_TEAMS ||--o{ HACKATHON_TASKS : has
   HACKATHON_TEAMS ||--o{ SUBMISSION_CHECKLIST : has
   DOCUMENTS ||--o{ RESUME_AI_CHECKS : produces
+  PROGRESS_TRACKS ||--o{ PROGRESS_LOGS : records
 ```
 
 **How to draw this in an interview:** start with `Users → Opportunities` as the centre. Add the many-to-many document relationship using `opportunity_documents`; that demonstrates normalization. Then branch to interview rounds/prep for internships and a one-to-one hackathon team for hackathons. Add share links as a user-owned snapshot, not a relationship from a public viewer to private data. Do not try to draw every column unless asked.
@@ -236,6 +239,7 @@ erDiagram
 | Hackathon collaboration tables | Team, members, ideas, tasks, and checklist items. | Distinct resources allow independent CRUD and validation. |
 | `share_links` | Snapshot metadata, hashed token, encrypted recoverable token, passcode data, expiry, status, and views. | Sharing is isolated from live dashboard authorization. |
 | `resume_ai_checks`, `user_ai_settings` | Persisted AI result and encrypted per-user settings. | AI runs can be shown later without repeating paid work. |
+| `progress_tracks`, `progress_logs` | User-owned learning tracks and one daily log per track, with flexible track-specific JSON metadata. | The normalized track/log relationship supports history and yearly heatmaps without a table per learning template. |
 
 ### Why PostgreSQL and migrations?
 

--- a/supabase/migrations/20260715151132_progress_logger.sql
+++ b/supabase/migrations/20260715151132_progress_logger.sql
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS progress_tracks (
     template_type IN ('leetcode', 'dev', 'system_design', 'mock', 'reading', 'custom')
   ),
   is_active BOOLEAN NOT NULL DEFAULT true,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT progress_tracks_id_user_id_key UNIQUE (id, user_id)
 );
 
 -- =============================================================================
@@ -30,7 +31,7 @@ CREATE TABLE IF NOT EXISTS progress_tracks (
 
 CREATE TABLE IF NOT EXISTS progress_logs (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  track_id UUID NOT NULL REFERENCES progress_tracks(id) ON DELETE CASCADE,
+  track_id UUID NOT NULL,
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   log_date DATE NOT NULL DEFAULT CURRENT_DATE,
   did_log BOOLEAN NOT NULL DEFAULT false,
@@ -39,7 +40,11 @@ CREATE TABLE IF NOT EXISTS progress_logs (
   metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
   mood TEXT CHECK (mood IN ('easy', 'moderate', 'hard')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  UNIQUE(track_id, log_date)
+  UNIQUE(track_id, log_date),
+  CONSTRAINT progress_logs_track_user_fkey
+    FOREIGN KEY (track_id, user_id)
+    REFERENCES progress_tracks(id, user_id)
+    ON DELETE CASCADE
 );
 
 -- The heatmap reads a user's logs by day; track history reads logs by track.

--- a/supabase/migrations/20260715151132_progress_logger.sql
+++ b/supabase/migrations/20260715151132_progress_logger.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- FutureTracker Progress Logger
+-- Tracks, daily logs, indexes, and Clerk-compatible Row-Level Security policies
+-- =============================================================================
+--
+-- FutureTracker uses Clerk identities mapped to public.users, not Supabase Auth
+-- identities. These foreign keys and policies therefore follow the existing
+-- application convention: rows belong to public.users(id), and direct database
+-- access is constrained through the Clerk subject in request JWT claims.
+--
+
+-- =============================================================================
+-- Progress tracks
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS progress_tracks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  template_type TEXT NOT NULL CHECK (
+    template_type IN ('leetcode', 'dev', 'system_design', 'mock', 'reading', 'custom')
+  ),
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =============================================================================
+-- Progress logs
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS progress_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  track_id UUID NOT NULL REFERENCES progress_tracks(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  log_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  did_log BOOLEAN NOT NULL DEFAULT false,
+  what_did_you_do TEXT,
+  what_did_you_learn TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  mood TEXT CHECK (mood IN ('easy', 'moderate', 'hard')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(track_id, log_date)
+);
+
+-- The heatmap reads a user's logs by day; track history reads logs by track.
+CREATE INDEX IF NOT EXISTS idx_progress_logs_user_date
+  ON progress_logs(user_id, log_date);
+CREATE INDEX IF NOT EXISTS idx_progress_logs_track_id
+  ON progress_logs(track_id);
+CREATE INDEX IF NOT EXISTS idx_progress_tracks_user_id
+  ON progress_tracks(user_id);
+
+-- =============================================================================
+-- Row-Level Security
+-- =============================================================================
+
+ALTER TABLE progress_tracks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE progress_logs ENABLE ROW LEVEL SECURITY;
+
+-- Policies are idempotent so the migration can be reapplied safely while
+-- developing a fresh database. WITH CHECK prevents inserts or updates that
+-- attempt to move a row to another user.
+DROP POLICY IF EXISTS "Users manage own progress tracks" ON progress_tracks;
+CREATE POLICY "Users manage own progress tracks" ON progress_tracks
+  FOR ALL
+  USING (
+    user_id IN (
+      SELECT id
+      FROM users
+      WHERE clerk_id = current_setting('request.jwt.claims', true)::json->>'sub'
+    )
+  )
+  WITH CHECK (
+    user_id IN (
+      SELECT id
+      FROM users
+      WHERE clerk_id = current_setting('request.jwt.claims', true)::json->>'sub'
+    )
+  );
+
+DROP POLICY IF EXISTS "Users manage own progress logs" ON progress_logs;
+CREATE POLICY "Users manage own progress logs" ON progress_logs
+  FOR ALL
+  USING (
+    user_id IN (
+      SELECT id
+      FROM users
+      WHERE clerk_id = current_setting('request.jwt.claims', true)::json->>'sub'
+    )
+  )
+  WITH CHECK (
+    user_id IN (
+      SELECT id
+      FROM users
+      WHERE clerk_id = current_setting('request.jwt.claims', true)::json->>'sub'
+    )
+  );

--- a/supabase/migrations/20260715154000_progress_logger_track_owner_fk.sql
+++ b/supabase/migrations/20260715154000_progress_logger_track_owner_fk.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- Progress Logger ownership integrity follow-up
+-- =============================================================================
+-- Apply the composite track/user constraint to databases that already ran
+-- 20260715151132_progress_logger.sql before this invariant was added.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'progress_tracks'::regclass
+      AND conname = 'progress_tracks_id_user_id_key'
+  ) THEN
+    ALTER TABLE progress_tracks
+      ADD CONSTRAINT progress_tracks_id_user_id_key UNIQUE (id, user_id);
+  END IF;
+END $$;
+
+ALTER TABLE progress_logs
+  DROP CONSTRAINT IF EXISTS progress_logs_track_id_fkey;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'progress_logs'::regclass
+      AND conname = 'progress_logs_track_user_fkey'
+  ) THEN
+    ALTER TABLE progress_logs
+      ADD CONSTRAINT progress_logs_track_user_fkey
+      FOREIGN KEY (track_id, user_id)
+      REFERENCES progress_tracks(id, user_id)
+      ON DELETE CASCADE;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

- add `progress_tracks` and `progress_logs` tables for the Progress Logger foundation
- add indexes for user/day heatmap reads, track history, and user-owned tracks
- enable Clerk-compatible Row-Level Security with explicit read and write ownership checks
- document the new data model in the interview architecture guide

## Implementation note

Issue #88 specifies `auth.users`, but FutureTracker authenticates with Clerk and maps identities into `public.users`. The migration follows the repository's existing `users(id)` foreign-key and Clerk-claim RLS pattern so it works with the current API.

## Validation

- `npm run check:architecture`
- migration structural assertions for tables, constraints, indexes, and RLS policies
- local Markdown link and anchor validation

## Scope

Schema, migration, RLS, and documentation only. No backend or frontend work is included.

Fixes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Progress Logger support for creating and managing personal learning tracks.
  * Added daily progress logs with track-specific details, mood tracking, and one entry per track per day.
  * Progress data is securely isolated to each account and automatically maintained when tracks are removed.

* **Documentation**
  * Updated product documentation with Progress Logger capabilities and data relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->