### PR TITLE
fix: improve footer watermark contrast

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -74,7 +74,7 @@ const Footer = () => {
 
             {/* Large Branding Text */}
             <div className="mt-20 select-none pointer-events-none w-full overflow-hidden flex justify-center">
-                <h1 className="text-[10vw] leading-none font-bold text-orange-600/15 dark:text-white/5 text-center whitespace-nowrap">
+                <h1 className="text-[10vw] leading-none font-bold text-orange-600/20 dark:text-white/10 text-center whitespace-nowrap">
                     FUTURE TRACKER
                 </h1>
             </div>


### PR DESCRIPTION
## Type of Change
- [x] Bug fix / accessibility improvement
- [ ] New feature
- [ ] Documentation

## Summary
Increase the footer watermark contrast so the decorative `FUTURE TRACKER` text remains legible in both themes.

## Changes Made
- raised the light-theme watermark opacity from 15% to 20%
- raised the dark-theme watermark opacity from 5% to 10%
- preserved the existing layout, typography, and decorative treatment

## Verification
- `git diff --check`
- `npm run build`

## Screenshots
Not included because the change is a single utility-class opacity adjustment; the production build completed successfully.

## Contributor Checklist
- [x] Change is limited to issue #100
- [x] Existing functionality is preserved
- [x] Validation commands completed
- [x] No unrelated files changed

Closes #100